### PR TITLE
feat: add persistent document ingestion lifecycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,10 @@ requires-python = ">=3.11"
 license = { file = "LICENSE" }
 authors = [{ name = "Ujjwal Kumar" }]
 dependencies = [
+    "beautifulsoup4>=4.12,<5",
     "fastapi>=0.115,<1",
     "pydantic-settings>=2.6,<3",
+    "pypdf>=5.1,<6",
     "python-multipart>=0.0.12,<1",
     "uvicorn[standard]>=0.32,<1",
 ]

--- a/src/doc2knowledge/api.py
+++ b/src/doc2knowledge/api.py
@@ -4,17 +4,31 @@ from fastapi import FastAPI
 
 from doc2knowledge import __version__
 from doc2knowledge.config import Settings
+from doc2knowledge.ingestion.service import IngestionService
+from doc2knowledge.routes.documents import router as documents_router
+from doc2knowledge.storage.metadata import MetadataRepository
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
     """Create a configured FastAPI application."""
+
+    resolved_settings = settings or Settings()
+    repository = MetadataRepository(resolved_settings.data_dir / "metadata.sqlite3")
+    ingestion_service = IngestionService(
+        repository,
+        resolved_settings.data_dir,
+        max_upload_bytes=resolved_settings.max_upload_bytes,
+    )
 
     app = FastAPI(
         title="doc2knowledge",
         version=__version__,
         description="Document ingestion, retrieval, and grounded question answering.",
     )
-    app.state.settings = settings or Settings()
+    app.state.settings = resolved_settings
+    app.state.metadata_repository = repository
+    app.state.ingestion_service = ingestion_service
+    app.include_router(documents_router)
 
     @app.get("/health", tags=["system"])
     def health() -> dict[str, str]:
@@ -25,6 +39,3 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         }
 
     return app
-
-
-app = create_app()

--- a/src/doc2knowledge/domain.py
+++ b/src/doc2knowledge/domain.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+
+class DocumentStatus(StrEnum):
+    PROCESSING = "processing"
+    READY = "ready"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class Document:
+    id: str
+    filename: str
+    media_type: str
+    sha256: str
+    status: DocumentStatus
+    created_at: datetime
+    chunk_count: int
+    error_message: str | None
+
+
+@dataclass(frozen=True)
+class Chunk:
+    id: str
+    document_id: str
+    ordinal: int
+    text: str
+    source_page: int | None
+    section: str | None
+
+
+@dataclass(frozen=True)
+class RetrievedChunk:
+    chunk: Chunk
+    document: Document
+    score: float
+
+
+@dataclass(frozen=True)
+class Citation:
+    label: str
+    document_id: str
+    filename: str
+    chunk_id: str
+    source_page: int | None
+    section: str | None
+
+
+@dataclass(frozen=True)
+class Answer:
+    text: str
+    citations: list[Citation]
+    evidence: list[RetrievedChunk]

--- a/src/doc2knowledge/ingestion/__init__.py
+++ b/src/doc2knowledge/ingestion/__init__.py
@@ -1,0 +1,1 @@
+"""Document ingestion pipeline."""

--- a/src/doc2knowledge/ingestion/chunking.py
+++ b/src/doc2knowledge/ingestion/chunking.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from doc2knowledge.ingestion.extractors import ExtractedDocument
+
+
+@dataclass(frozen=True)
+class ChunkDraft:
+    ordinal: int
+    text: str
+    source_page: int | None
+    section: str | None
+
+
+def chunk_document(
+    document: ExtractedDocument,
+    *,
+    chunk_size: int = 1000,
+    chunk_overlap: int = 200,
+) -> list[ChunkDraft]:
+    if chunk_size < 1:
+        raise ValueError("chunk_size must be positive")
+    if chunk_overlap < 0 or chunk_overlap >= chunk_size:
+        raise ValueError("chunk_overlap must be between zero and chunk_size")
+
+    chunks: list[ChunkDraft] = []
+    step = chunk_size - chunk_overlap
+    for section in document.sections:
+        text = section.text.strip()
+        for start in range(0, len(text), step):
+            value = text[start : start + chunk_size].strip()
+            if value:
+                chunks.append(
+                    ChunkDraft(
+                        ordinal=len(chunks),
+                        text=value,
+                        source_page=section.source_page,
+                        section=section.section,
+                    )
+                )
+            if start + chunk_size >= len(text):
+                break
+    return chunks

--- a/src/doc2knowledge/ingestion/extractors.py
+++ b/src/doc2knowledge/ingestion/extractors.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+
+from bs4 import BeautifulSoup
+from pypdf import PdfReader
+
+
+class ExtractionError(ValueError):
+    """Base class for extraction failures visible to the caller."""
+
+
+class UnsupportedMediaTypeError(ExtractionError):
+    pass
+
+
+class EmptyDocumentError(ExtractionError):
+    pass
+
+
+@dataclass(frozen=True)
+class ExtractedSection:
+    text: str
+    source_page: int | None = None
+    section: str | None = None
+
+
+@dataclass(frozen=True)
+class ExtractedDocument:
+    sections: list[ExtractedSection]
+
+
+SUPPORTED_MEDIA_TYPES = {
+    "application/pdf",
+    "text/html",
+    "text/plain",
+    "text/markdown",
+}
+
+
+def extract_document(data: bytes, media_type: str) -> ExtractedDocument:
+    normalized_media_type = media_type.split(";", maxsplit=1)[0].strip().lower()
+    if normalized_media_type not in SUPPORTED_MEDIA_TYPES:
+        raise UnsupportedMediaTypeError(normalized_media_type)
+
+    if normalized_media_type == "application/pdf":
+        sections = _extract_pdf(data)
+    elif normalized_media_type == "text/html":
+        sections = _extract_html(data)
+    else:
+        sections = [ExtractedSection(text=_decode_utf8(data))]
+
+    usable_sections = [
+        ExtractedSection(
+            text=section.text.strip(),
+            source_page=section.source_page,
+            section=section.section,
+        )
+        for section in sections
+        if section.text.strip()
+    ]
+    if not usable_sections:
+        raise EmptyDocumentError("document contains no extractable text")
+    return ExtractedDocument(sections=usable_sections)
+
+
+def _decode_utf8(data: bytes) -> str:
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ExtractionError("document is not valid UTF-8") from error
+
+
+def _extract_html(data: bytes) -> list[ExtractedSection]:
+    soup = BeautifulSoup(_decode_utf8(data), "html.parser")
+    title_node = soup.find(["h1", "title"])
+    title = title_node.get_text(" ", strip=True) if title_node is not None else None
+    return [
+        ExtractedSection(
+            text=soup.get_text("\n", strip=True),
+            section=title or None,
+        )
+    ]
+
+
+def _extract_pdf(data: bytes) -> list[ExtractedSection]:
+    try:
+        reader = PdfReader(BytesIO(data))
+        return [
+            ExtractedSection(
+                text=page.extract_text() or "",
+                source_page=index,
+            )
+            for index, page in enumerate(reader.pages, start=1)
+        ]
+    except Exception as error:
+        raise ExtractionError("unable to parse PDF") from error

--- a/src/doc2knowledge/ingestion/service.py
+++ b/src/doc2knowledge/ingestion/service.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import hashlib
+import shutil
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID, uuid4, uuid5
+
+from doc2knowledge.domain import Chunk, Document, DocumentStatus
+from doc2knowledge.ingestion.chunking import chunk_document
+from doc2knowledge.ingestion.extractors import (
+    SUPPORTED_MEDIA_TYPES,
+    ExtractionError,
+    UnsupportedMediaTypeError,
+    extract_document,
+)
+from doc2knowledge.storage.metadata import MetadataRepository
+
+
+class UploadTooLargeError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class IngestionResult:
+    document: Document
+    duplicate: bool
+
+
+class IngestionService:
+    def __init__(
+        self,
+        repository: MetadataRepository,
+        data_dir: Path,
+        *,
+        max_upload_bytes: int,
+        chunk_size: int = 1000,
+        chunk_overlap: int = 200,
+    ) -> None:
+        self._repository = repository
+        self._documents_dir = data_dir / "documents"
+        self._documents_dir.mkdir(parents=True, exist_ok=True)
+        self._max_upload_bytes = max_upload_bytes
+        self._chunk_size = chunk_size
+        self._chunk_overlap = chunk_overlap
+
+    def ingest(self, filename: str, media_type: str, data: bytes) -> IngestionResult:
+        if len(data) > self._max_upload_bytes:
+            raise UploadTooLargeError(
+                f"upload contains {len(data)} bytes; limit is {self._max_upload_bytes}"
+            )
+
+        normalized_media_type = media_type.split(";", maxsplit=1)[0].strip().lower()
+        if normalized_media_type not in SUPPORTED_MEDIA_TYPES:
+            raise UnsupportedMediaTypeError(normalized_media_type)
+
+        content_hash = hashlib.sha256(data).hexdigest()
+        duplicate = self._repository.get_document_by_hash(content_hash)
+        if duplicate is not None:
+            return IngestionResult(document=duplicate, duplicate=True)
+
+        document_id = str(uuid4())
+        document = Document(
+            id=document_id,
+            filename=Path(filename).name or "document",
+            media_type=normalized_media_type,
+            sha256=content_hash,
+            status=DocumentStatus.PROCESSING,
+            created_at=datetime.now(UTC),
+            chunk_count=0,
+            error_message=None,
+        )
+        self._repository.create_document(document)
+        document_dir = self._documents_dir / document.id
+        document_dir.mkdir(parents=True, exist_ok=False)
+        (document_dir / "source").write_bytes(data)
+
+        try:
+            extracted = extract_document(data, normalized_media_type)
+            drafts = chunk_document(
+                extracted,
+                chunk_size=self._chunk_size,
+                chunk_overlap=self._chunk_overlap,
+            )
+            chunks = [
+                Chunk(
+                    id=str(uuid5(UUID(document.id), str(draft.ordinal))),
+                    document_id=document.id,
+                    ordinal=draft.ordinal,
+                    text=draft.text,
+                    source_page=draft.source_page,
+                    section=draft.section,
+                )
+                for draft in drafts
+            ]
+            self._repository.save_chunks(chunks)
+            ready = replace(
+                document,
+                status=DocumentStatus.READY,
+                chunk_count=len(chunks),
+            )
+            self._repository.update_document(ready)
+            return IngestionResult(document=ready, duplicate=False)
+        except ExtractionError as error:
+            failed = replace(
+                document,
+                status=DocumentStatus.FAILED,
+                error_message=str(error),
+            )
+            self._repository.update_document(failed)
+            raise
+
+    def get_document(self, document_id: str) -> Document | None:
+        return self._repository.get_document(document_id)
+
+    def list_documents(self) -> list[Document]:
+        return self._repository.list_documents()
+
+    def delete_document(self, document_id: str) -> bool:
+        deleted = self._repository.delete_document(document_id)
+        if deleted:
+            shutil.rmtree(self._documents_dir / document_id, ignore_errors=True)
+        return deleted

--- a/src/doc2knowledge/routes/__init__.py
+++ b/src/doc2knowledge/routes/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP route modules."""

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Annotated, cast
 
-from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
+from fastapi import (
+    APIRouter,
+    File,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
 from pydantic import BaseModel, ConfigDict
 
 from doc2knowledge.domain import Document, DocumentStatus
@@ -94,12 +102,16 @@ def list_documents(request: Request) -> list[DocumentResponse]:
 def get_document(document_id: str, request: Request) -> DocumentResponse:
     document = _service(request).get_document(document_id)
     if document is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
+        )
     return _response(document)
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_document(document_id: str, request: Request) -> Response:
     if not _service(request).delete_document(document_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
+        )
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import cast
+
+from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
+from pydantic import BaseModel, ConfigDict
+
+from doc2knowledge.domain import Document, DocumentStatus
+from doc2knowledge.ingestion.extractors import (
+    EmptyDocumentError,
+    ExtractionError,
+    UnsupportedMediaTypeError,
+)
+from doc2knowledge.ingestion.service import IngestionService, UploadTooLargeError
+
+router = APIRouter(prefix="/documents", tags=["documents"])
+
+
+class DocumentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    filename: str
+    media_type: str
+    sha256: str
+    status: DocumentStatus
+    created_at: datetime
+    chunk_count: int
+    error_message: str | None
+
+
+class UploadResponse(BaseModel):
+    document: DocumentResponse
+    duplicate: bool
+
+
+def _service(request: Request) -> IngestionService:
+    return cast(IngestionService, request.app.state.ingestion_service)
+
+
+def _response(document: Document) -> DocumentResponse:
+    return DocumentResponse.model_validate(document)
+
+
+@router.post("", response_model=UploadResponse, status_code=status.HTTP_201_CREATED)
+async def upload_document(
+    request: Request,
+    response: Response,
+    file: UploadFile = File(...),
+) -> UploadResponse:
+    data = await file.read()
+    try:
+        result = _service(request).ingest(
+            filename=file.filename or "document",
+            media_type=file.content_type or "application/octet-stream",
+            data=data,
+        )
+    except UploadTooLargeError as error:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail={"code": "upload_too_large", "message": str(error)},
+        ) from error
+    except UnsupportedMediaTypeError as error:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail={"code": "unsupported_media_type", "message": str(error)},
+        ) from error
+    except EmptyDocumentError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"code": "empty_document", "message": str(error)},
+        ) from error
+    except ExtractionError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"code": "extraction_failed", "message": str(error)},
+        ) from error
+
+    if result.duplicate:
+        response.status_code = status.HTTP_200_OK
+    return UploadResponse(
+        document=_response(result.document),
+        duplicate=result.duplicate,
+    )
+
+
+@router.get("", response_model=list[DocumentResponse])
+def list_documents(request: Request) -> list[DocumentResponse]:
+    return [_response(document) for document in _service(request).list_documents()]
+
+
+@router.get("/{document_id}", response_model=DocumentResponse)
+def get_document(document_id: str, request: Request) -> DocumentResponse:
+    document = _service(request).get_document(document_id)
+    if document is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
+    return _response(document)
+
+
+@router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_document(document_id: str, request: Request) -> Response:
+    if not _service(request).delete_document(document_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -102,16 +102,12 @@ def list_documents(request: Request) -> list[DocumentResponse]:
 def get_document(document_id: str, request: Request) -> DocumentResponse:
     document = _service(request).get_document(document_id)
     if document is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
     return _response(document)
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_document(document_id: str, request: Request) -> Response:
     if not _service(request).delete_document(document_id):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import cast
+from typing import Annotated, cast
 
 from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
 from pydantic import BaseModel, ConfigDict
@@ -47,7 +47,7 @@ def _response(document: Document) -> DocumentResponse:
 async def upload_document(
     request: Request,
     response: Response,
-    file: UploadFile = File(...),
+    file: Annotated[UploadFile, File()],
 ) -> UploadResponse:
     data = await file.read()
     try:

--- a/src/doc2knowledge/storage/__init__.py
+++ b/src/doc2knowledge/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Persistence adapters."""

--- a/src/doc2knowledge/storage/metadata.py
+++ b/src/doc2knowledge/storage/metadata.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable
+from datetime import datetime
+from pathlib import Path
+from typing import cast
+
+from doc2knowledge.domain import Chunk, Document, DocumentStatus
+
+
+class MetadataRepository:
+    """Persist document and chunk metadata in SQLite."""
+
+    def __init__(self, database_path: Path) -> None:
+        self._database_path = database_path
+        self._database_path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._database_path)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        return connection
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS documents (
+                    id TEXT PRIMARY KEY,
+                    filename TEXT NOT NULL,
+                    media_type TEXT NOT NULL,
+                    sha256 TEXT NOT NULL UNIQUE,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    chunk_count INTEGER NOT NULL DEFAULT 0,
+                    error_message TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS chunks (
+                    id TEXT PRIMARY KEY,
+                    document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+                    ordinal INTEGER NOT NULL,
+                    text TEXT NOT NULL,
+                    source_page INTEGER,
+                    section TEXT,
+                    UNIQUE(document_id, ordinal)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_chunks_document_id
+                ON chunks(document_id);
+                """
+            )
+
+    def create_document(self, document: Document) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO documents (
+                    id, filename, media_type, sha256, status,
+                    created_at, chunk_count, error_message
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    document.id,
+                    document.filename,
+                    document.media_type,
+                    document.sha256,
+                    document.status.value,
+                    document.created_at.isoformat(),
+                    document.chunk_count,
+                    document.error_message,
+                ),
+            )
+
+    def update_document(self, document: Document) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE documents
+                SET filename = ?, media_type = ?, sha256 = ?, status = ?,
+                    created_at = ?, chunk_count = ?, error_message = ?
+                WHERE id = ?
+                """,
+                (
+                    document.filename,
+                    document.media_type,
+                    document.sha256,
+                    document.status.value,
+                    document.created_at.isoformat(),
+                    document.chunk_count,
+                    document.error_message,
+                    document.id,
+                ),
+            )
+
+    def get_document(self, document_id: str) -> Document | None:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM documents WHERE id = ?",
+                (document_id,),
+            ).fetchone()
+        return self._document_from_row(row) if row is not None else None
+
+    def get_document_by_hash(self, sha256: str) -> Document | None:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM documents WHERE sha256 = ?",
+                (sha256,),
+            ).fetchone()
+        return self._document_from_row(row) if row is not None else None
+
+    def list_documents(self) -> list[Document]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT * FROM documents ORDER BY created_at, id"
+            ).fetchall()
+        return [self._document_from_row(row) for row in rows]
+
+    def save_chunks(self, chunks: Iterable[Chunk]) -> None:
+        values = [
+            (
+                chunk.id,
+                chunk.document_id,
+                chunk.ordinal,
+                chunk.text,
+                chunk.source_page,
+                chunk.section,
+            )
+            for chunk in chunks
+        ]
+        if not values:
+            return
+        with self._connect() as connection:
+            connection.executemany(
+                """
+                INSERT INTO chunks (
+                    id, document_id, ordinal, text, source_page, section
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                values,
+            )
+
+    def get_chunks(self, document_id: str) -> list[Chunk]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM chunks
+                WHERE document_id = ?
+                ORDER BY ordinal
+                """,
+                (document_id,),
+            ).fetchall()
+        return [self._chunk_from_row(row) for row in rows]
+
+    def get_chunk(self, chunk_id: str) -> Chunk | None:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM chunks WHERE id = ?",
+                (chunk_id,),
+            ).fetchone()
+        return self._chunk_from_row(row) if row is not None else None
+
+    def delete_document(self, document_id: str) -> bool:
+        with self._connect() as connection:
+            cursor = connection.execute(
+                "DELETE FROM documents WHERE id = ?",
+                (document_id,),
+            )
+        return cursor.rowcount > 0
+
+    @staticmethod
+    def _document_from_row(row: sqlite3.Row) -> Document:
+        return Document(
+            id=cast(str, row["id"]),
+            filename=cast(str, row["filename"]),
+            media_type=cast(str, row["media_type"]),
+            sha256=cast(str, row["sha256"]),
+            status=DocumentStatus(cast(str, row["status"])),
+            created_at=datetime.fromisoformat(cast(str, row["created_at"])),
+            chunk_count=cast(int, row["chunk_count"]),
+            error_message=cast(str | None, row["error_message"]),
+        )
+
+    @staticmethod
+    def _chunk_from_row(row: sqlite3.Row) -> Chunk:
+        return Chunk(
+            id=cast(str, row["id"]),
+            document_id=cast(str, row["document_id"]),
+            ordinal=cast(int, row["ordinal"]),
+            text=cast(str, row["text"]),
+            source_page=cast(int | None, row["source_page"]),
+            section=cast(str | None, row["section"]),
+        )

--- a/src/doc2knowledge/storage/metadata.py
+++ b/src/doc2knowledge/storage/metadata.py
@@ -113,9 +113,7 @@ class MetadataRepository:
 
     def list_documents(self) -> list[Document]:
         with self._connect() as connection:
-            rows = connection.execute(
-                "SELECT * FROM documents ORDER BY created_at, id"
-            ).fetchall()
+            rows = connection.execute("SELECT * FROM documents ORDER BY created_at, id").fetchall()
         return [self._document_from_row(row) for row in rows]
 
     def save_chunks(self, chunks: Iterable[Chunk]) -> None:

--- a/tests/api/test_documents.py
+++ b/tests/api/test_documents.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from doc2knowledge.api import create_app
+from doc2knowledge.config import Settings
+
+
+def make_client(tmp_path: Path, max_upload_bytes: int = 1024) -> TestClient:
+    return TestClient(
+        create_app(
+            Settings(
+                data_dir=tmp_path,
+                max_upload_bytes=max_upload_bytes,
+            )
+        )
+    )
+
+
+def test_upload_list_get_duplicate_and_delete_document(tmp_path: Path) -> None:
+    client = make_client(tmp_path)
+
+    uploaded = client.post(
+        "/documents",
+        files={"file": ("notes.txt", b"alpha beta gamma", "text/plain")},
+    )
+
+    assert uploaded.status_code == 201
+    body = uploaded.json()
+    document_id = body["document"]["id"]
+    assert body["duplicate"] is False
+    assert body["document"]["status"] == "ready"
+    assert body["document"]["chunk_count"] == 1
+
+    duplicate = client.post(
+        "/documents",
+        files={"file": ("renamed.txt", b"alpha beta gamma", "text/plain")},
+    )
+    assert duplicate.status_code == 200
+    assert duplicate.json()["duplicate"] is True
+    assert duplicate.json()["document"]["id"] == document_id
+
+    listed = client.get("/documents")
+    assert listed.status_code == 200
+    assert [item["id"] for item in listed.json()] == [document_id]
+
+    fetched = client.get(f"/documents/{document_id}")
+    assert fetched.status_code == 200
+    assert fetched.json()["filename"] == "notes.txt"
+
+    deleted = client.delete(f"/documents/{document_id}")
+    assert deleted.status_code == 204
+    assert client.get(f"/documents/{document_id}").status_code == 404
+
+
+def test_upload_validation_errors_are_explicit(tmp_path: Path) -> None:
+    client = make_client(tmp_path, max_upload_bytes=4)
+
+    too_large = client.post(
+        "/documents",
+        files={"file": ("large.txt", b"12345", "text/plain")},
+    )
+    unsupported = client.post(
+        "/documents",
+        files={"file": ("blob.bin", b"123", "application/octet-stream")},
+    )
+    empty = client.post(
+        "/documents",
+        files={"file": ("empty.txt", b"   ", "text/plain")},
+    )
+
+    assert too_large.status_code == 413
+    assert too_large.json()["detail"]["code"] == "upload_too_large"
+    assert unsupported.status_code == 415
+    assert unsupported.json()["detail"]["code"] == "unsupported_media_type"
+    assert empty.status_code == 422
+    assert empty.json()["detail"]["code"] == "empty_document"

--- a/tests/ingestion/test_chunking.py
+++ b/tests/ingestion/test_chunking.py
@@ -1,0 +1,20 @@
+from doc2knowledge.ingestion.chunking import chunk_document
+from doc2knowledge.ingestion.extractors import ExtractedDocument, ExtractedSection
+
+
+def test_chunking_preserves_order_and_source_metadata() -> None:
+    extracted = ExtractedDocument(
+        sections=[
+            ExtractedSection(text="abcdefghij", source_page=3, section="Alpha"),
+            ExtractedSection(text="klmnop", source_page=4, section="Beta"),
+        ]
+    )
+
+    chunks = chunk_document(extracted, chunk_size=6, chunk_overlap=2)
+
+    assert [chunk.ordinal for chunk in chunks] == [0, 1, 2]
+    assert [chunk.text for chunk in chunks] == ["abcdef", "efghij", "klmnop"]
+    assert chunks[0].source_page == 3
+    assert chunks[0].section == "Alpha"
+    assert chunks[2].source_page == 4
+    assert chunks[2].section == "Beta"

--- a/tests/ingestion/test_extractors.py
+++ b/tests/ingestion/test_extractors.py
@@ -1,0 +1,29 @@
+import pytest
+
+from doc2knowledge.ingestion.extractors import (
+    EmptyDocumentError,
+    UnsupportedMediaTypeError,
+    extract_document,
+)
+
+
+def test_extracts_text_markdown_and_html() -> None:
+    text = extract_document(b"hello\nworld", "text/plain")
+    markdown = extract_document(b"# Heading\nbody", "text/markdown")
+    html = extract_document(
+        b"<html><body><h1>Title</h1><p>Body</p></body></html>",
+        "text/html",
+    )
+
+    assert [section.text for section in text.sections] == ["hello\nworld"]
+    assert [section.text for section in markdown.sections] == ["# Heading\nbody"]
+    assert html.sections[0].text == "Title\nBody"
+    assert html.sections[0].section == "Title"
+
+
+def test_rejects_unsupported_and_empty_documents() -> None:
+    with pytest.raises(UnsupportedMediaTypeError):
+        extract_document(b"data", "application/octet-stream")
+
+    with pytest.raises(EmptyDocumentError):
+        extract_document(b"   \n", "text/plain")

--- a/tests/storage/test_metadata.py
+++ b/tests/storage/test_metadata.py
@@ -1,0 +1,69 @@
+from datetime import UTC, datetime
+from pathlib import Path
+
+from doc2knowledge.domain import Chunk, Document, DocumentStatus
+from doc2knowledge.storage.metadata import MetadataRepository
+
+
+def make_document(document_id: str = "doc-1") -> Document:
+    return Document(
+        id=document_id,
+        filename="notes.txt",
+        media_type="text/plain",
+        sha256="abc123",
+        status=DocumentStatus.PROCESSING,
+        created_at=datetime(2026, 7, 11, tzinfo=UTC),
+        chunk_count=0,
+        error_message=None,
+    )
+
+
+def test_repository_persists_documents_chunks_and_deletion(tmp_path: Path) -> None:
+    database_path = tmp_path / "metadata.sqlite3"
+    repository = MetadataRepository(database_path)
+    document = make_document()
+    chunks = [
+        Chunk(
+            id="chunk-1",
+            document_id=document.id,
+            ordinal=0,
+            text="first chunk",
+            source_page=1,
+            section="Introduction",
+        ),
+        Chunk(
+            id="chunk-2",
+            document_id=document.id,
+            ordinal=1,
+            text="second chunk",
+            source_page=2,
+            section=None,
+        ),
+    ]
+
+    repository.create_document(document)
+    repository.save_chunks(chunks)
+    repository.update_document(
+        Document(
+            **{
+                **document.__dict__,
+                "status": DocumentStatus.READY,
+                "chunk_count": len(chunks),
+            }
+        )
+    )
+
+    reopened = MetadataRepository(database_path)
+    stored = reopened.get_document(document.id)
+
+    assert stored is not None
+    assert stored.status is DocumentStatus.READY
+    assert stored.chunk_count == 2
+    assert reopened.get_document_by_hash("abc123") == stored
+    assert reopened.list_documents() == [stored]
+    assert reopened.get_chunks(document.id) == chunks
+
+    assert reopened.delete_document(document.id) is True
+    assert reopened.get_document(document.id) is None
+    assert reopened.get_chunks(document.id) == []
+    assert reopened.delete_document(document.id) is False


### PR DESCRIPTION
## Summary

Adds the first real application workflow: validated document upload, extraction, deterministic chunking, SQLite metadata, deduplication, and lifecycle APIs.

## Highlights

- UUID document identity; filenames are metadata only
- SHA-256 duplicate detection
- persisted `Document` and `Chunk` records
- PDF, HTML, plain text, and Markdown extraction
- page/section-aware chunk metadata
- explicit 413/415/422 failures instead of silent empty indexes
- upload, list, status, and delete endpoints
- source files stored under document-specific directories
- persistence and API behavior tests

## Stack

Targets `feat/foundation-ci` and should merge after PR #5. It intentionally does not embed or index chunks yet; that is isolated in the next PR.