### PR TITLE
feat: add Mixedbread embeddings and unified vector index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,13 @@ license = { file = "LICENSE" }
 authors = [{ name = "Ujjwal Kumar" }]
 dependencies = [
     "beautifulsoup4>=4.12,<5",
+    "faiss-cpu>=1.8,<2",
     "fastapi>=0.115,<1",
+    "numpy>=1.26,<3",
     "pydantic-settings>=2.6,<3",
     "pypdf>=5.1,<6",
     "python-multipart>=0.0.12,<1",
+    "sentence-transformers>=3.3,<6",
     "uvicorn[standard]>=0.32,<1",
 ]
 
@@ -48,9 +51,16 @@ python_version = "3.11"
 strict = true
 packages = ["doc2knowledge"]
 
+[[tool.mypy.overrides]]
+module = ["faiss", "faiss.*", "sentence_transformers", "sentence_transformers.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-ra --strict-markers"
+markers = [
+    "integration: tests that may download models or use external services",
+]
 
 [tool.coverage.run]
 source = ["doc2knowledge"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ packages = ["doc2knowledge"]
 [[tool.mypy.overrides]]
 module = ["faiss", "faiss.*", "sentence_transformers", "sentence_transformers.*"]
 ignore_missing_imports = true
+follow_imports = "skip"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/doc2knowledge/embeddings/__init__.py
+++ b/src/doc2knowledge/embeddings/__init__.py
@@ -1,0 +1,1 @@
+"""Embedding service interfaces and adapters."""

--- a/src/doc2knowledge/embeddings/base.py
+++ b/src/doc2knowledge/embeddings/base.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+
+class EmbeddingService(Protocol):
+    @property
+    def dimensions(self) -> int: ...
+
+    @property
+    def model_name(self) -> str: ...
+
+    def embed_documents(self, texts: Sequence[str]) -> list[list[float]]: ...
+
+    def embed_query(self, query: str) -> list[float]: ...

--- a/src/doc2knowledge/embeddings/mixedbread.py
+++ b/src/doc2knowledge/embeddings/mixedbread.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from threading import Lock
-from typing import Any, Protocol, cast
+from typing import Protocol, cast
 
 import numpy as np
 from numpy.typing import NDArray

--- a/src/doc2knowledge/embeddings/mixedbread.py
+++ b/src/doc2knowledge/embeddings/mixedbread.py
@@ -90,4 +90,4 @@ class MixedbreadEmbeddingService:
                         self._model_name,
                         self._dimensions,
                     )
-        return cast(SentenceEncoder, self._model)
+        return self._model

--- a/src/doc2knowledge/embeddings/mixedbread.py
+++ b/src/doc2knowledge/embeddings/mixedbread.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from threading import Lock
+from typing import Any, Protocol, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+class SentenceEncoder(Protocol):
+    def encode(
+        self,
+        sentences: str | Sequence[str],
+        *,
+        prompt_name: str | None = None,
+        normalize_embeddings: bool = True,
+        convert_to_numpy: bool = True,
+    ) -> NDArray[np.float32]: ...
+
+
+ModelFactory = Callable[[str, int], SentenceEncoder]
+
+
+def _default_model_factory(model_name: str, dimensions: int) -> SentenceEncoder:
+    from sentence_transformers import SentenceTransformer
+
+    model = SentenceTransformer(model_name, truncate_dim=dimensions)
+    return cast(SentenceEncoder, model)
+
+
+class MixedbreadEmbeddingService:
+    """Lazy, reusable adapter for mxbai retrieval embeddings."""
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        dimensions: int,
+        model_factory: ModelFactory = _default_model_factory,
+    ) -> None:
+        self._model_name = model_name
+        self._dimensions = dimensions
+        self._model_factory = model_factory
+        self._model: SentenceEncoder | None = None
+        self._model_lock = Lock()
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions
+
+    def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        encoded = self._encoder().encode(
+            list(texts),
+            normalize_embeddings=True,
+            convert_to_numpy=True,
+        )
+        array = np.asarray(encoded, dtype=np.float32)
+        if array.ndim != 2 or array.shape != (len(texts), self._dimensions):
+            raise ValueError(
+                "embedding model returned unexpected document dimensions: "
+                f"{array.shape}"
+            )
+        return [[float(value) for value in row] for row in array]
+
+    def embed_query(self, query: str) -> list[float]:
+        if not query.strip():
+            raise ValueError("query must not be empty")
+        encoded = self._encoder().encode(
+            query,
+            prompt_name="query",
+            normalize_embeddings=True,
+            convert_to_numpy=True,
+        )
+        array = np.asarray(encoded, dtype=np.float32).reshape(-1)
+        if array.shape != (self._dimensions,):
+            raise ValueError(
+                "embedding model returned unexpected query dimensions: "
+                f"{array.shape}"
+            )
+        return [float(value) for value in array]
+
+    def _encoder(self) -> SentenceEncoder:
+        if self._model is None:
+            with self._model_lock:
+                if self._model is None:
+                    self._model = self._model_factory(
+                        self._model_name,
+                        self._dimensions,
+                    )
+        return cast(SentenceEncoder, self._model)

--- a/src/doc2knowledge/embeddings/mixedbread.py
+++ b/src/doc2knowledge/embeddings/mixedbread.py
@@ -64,8 +64,7 @@ class MixedbreadEmbeddingService:
         array = np.asarray(encoded, dtype=np.float32)
         if array.ndim != 2 or array.shape != (len(texts), self._dimensions):
             raise ValueError(
-                "embedding model returned unexpected document dimensions: "
-                f"{array.shape}"
+                f"embedding model returned unexpected document dimensions: {array.shape}"
             )
         return [[float(value) for value in row] for row in array]
 
@@ -80,10 +79,7 @@ class MixedbreadEmbeddingService:
         )
         array = np.asarray(encoded, dtype=np.float32).reshape(-1)
         if array.shape != (self._dimensions,):
-            raise ValueError(
-                "embedding model returned unexpected query dimensions: "
-                f"{array.shape}"
-            )
+            raise ValueError(f"embedding model returned unexpected query dimensions: {array.shape}")
         return [float(value) for value in array]
 
     def _encoder(self) -> SentenceEncoder:

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Annotated, cast
 
-from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
+from fastapi import (
+    APIRouter,
+    File,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
 from pydantic import BaseModel, ConfigDict
 
 from doc2knowledge.domain import Document, DocumentStatus
@@ -94,12 +102,16 @@ def list_documents(request: Request) -> list[DocumentResponse]:
 def get_document(document_id: str, request: Request) -> DocumentResponse:
     document = _service(request).get_document(document_id)
     if document is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
+        )
     return _response(document)
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_document(document_id: str, request: Request) -> Response:
     if not _service(request).delete_document(document_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
+        )
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -102,16 +102,12 @@ def list_documents(request: Request) -> list[DocumentResponse]:
 def get_document(document_id: str, request: Request) -> DocumentResponse:
     document = _service(request).get_document(document_id)
     if document is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
     return _response(document)
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_document(document_id: str, request: Request) -> Response:
     if not _service(request).delete_document(document_id):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import cast
+from typing import Annotated, cast
 
 from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
 from pydantic import BaseModel, ConfigDict
@@ -47,7 +47,7 @@ def _response(document: Document) -> DocumentResponse:
 async def upload_document(
     request: Request,
     response: Response,
-    file: UploadFile = File(...),
+    file: Annotated[UploadFile, File()],
 ) -> UploadResponse:
     data = await file.read()
     try:

--- a/src/doc2knowledge/storage/metadata.py
+++ b/src/doc2knowledge/storage/metadata.py
@@ -113,9 +113,7 @@ class MetadataRepository:
 
     def list_documents(self) -> list[Document]:
         with self._connect() as connection:
-            rows = connection.execute(
-                "SELECT * FROM documents ORDER BY created_at, id"
-            ).fetchall()
+            rows = connection.execute("SELECT * FROM documents ORDER BY created_at, id").fetchall()
         return [self._document_from_row(row) for row in rows]
 
     def save_chunks(self, chunks: Iterable[Chunk]) -> None:

--- a/src/doc2knowledge/storage/vectors.py
+++ b/src/doc2knowledge/storage/vectors.py
@@ -48,7 +48,7 @@ class VectorRepository:
         self._index_path = self._path / "index.faiss"
         self._mapping_path = self._path / "mapping.json"
         self._manifest_path = self._path / "manifest.json"
-        self._index = faiss.IndexFlatIP(dimensions)
+        self._index: faiss.Index = faiss.IndexFlatIP(dimensions)
         self._mappings: list[_Mapping] = []
         self._load_if_present()
 

--- a/src/doc2knowledge/storage/vectors.py
+++ b/src/doc2knowledge/storage/vectors.py
@@ -134,9 +134,7 @@ class VectorRepository:
     def _matrix(self, vectors: list[list[float]]) -> NDArray[np.float32]:
         matrix = np.asarray(vectors, dtype=np.float32)
         if matrix.ndim != 2 or matrix.shape[1] != self._dimensions:
-            raise ValueError(
-                f"vectors must have {self._dimensions} dimensions; got {matrix.shape}"
-            )
+            raise ValueError(f"vectors must have {self._dimensions} dimensions; got {matrix.shape}")
         norms = np.linalg.norm(matrix, axis=1, keepdims=True)
         if np.any(norms == 0):
             raise ValueError("zero vectors cannot be indexed")

--- a/src/doc2knowledge/storage/vectors.py
+++ b/src/doc2knowledge/storage/vectors.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from threading import RLock
+from typing import cast
+
+import faiss
+import numpy as np
+from numpy.typing import NDArray
+
+
+class IncompatibleIndexError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class VectorRecord:
+    chunk_id: str
+    document_id: str
+    vector: list[float]
+
+
+@dataclass(frozen=True)
+class VectorMatch:
+    chunk_id: str
+    document_id: str
+    score: float
+
+
+@dataclass(frozen=True)
+class _Mapping:
+    chunk_id: str
+    document_id: str
+
+
+class VectorRepository:
+    """One persistent cosine-similarity FAISS collection for all chunks."""
+
+    def __init__(self, path: Path, *, model_name: str, dimensions: int) -> None:
+        self._path = path
+        self._path.mkdir(parents=True, exist_ok=True)
+        self._model_name = model_name
+        self._dimensions = dimensions
+        self._lock = RLock()
+        self._index_path = self._path / "index.faiss"
+        self._mapping_path = self._path / "mapping.json"
+        self._manifest_path = self._path / "manifest.json"
+        self._index = faiss.IndexFlatIP(dimensions)
+        self._mappings: list[_Mapping] = []
+        self._load_if_present()
+
+    @property
+    def size(self) -> int:
+        return int(self._index.ntotal)
+
+    def add(self, records: list[VectorRecord]) -> None:
+        if not records:
+            return
+        with self._lock:
+            existing_ids = {mapping.chunk_id for mapping in self._mappings}
+            incoming_ids = [record.chunk_id for record in records]
+            if len(set(incoming_ids)) != len(incoming_ids):
+                raise ValueError("chunk IDs must be unique within a batch")
+            if existing_ids.intersection(incoming_ids):
+                raise ValueError("chunk ID already exists in vector index")
+
+            vectors = self._matrix([record.vector for record in records])
+            self._index.add(vectors)
+            self._mappings.extend(
+                _Mapping(record.chunk_id, record.document_id) for record in records
+            )
+            self._persist()
+
+    def search(
+        self,
+        query: list[float],
+        top_k: int,
+        *,
+        document_ids: set[str] | None = None,
+    ) -> list[VectorMatch]:
+        if top_k < 1:
+            raise ValueError("top_k must be positive")
+        with self._lock:
+            if self._index.ntotal == 0:
+                return []
+            query_matrix = self._matrix([query])
+            scores, indices = self._index.search(query_matrix, int(self._index.ntotal))
+            matches: list[VectorMatch] = []
+            for score, index in zip(scores[0], indices[0], strict=True):
+                if index < 0:
+                    continue
+                mapping = self._mappings[int(index)]
+                if document_ids is not None and mapping.document_id not in document_ids:
+                    continue
+                matches.append(
+                    VectorMatch(
+                        chunk_id=mapping.chunk_id,
+                        document_id=mapping.document_id,
+                        score=float(score),
+                    )
+                )
+                if len(matches) == top_k:
+                    break
+            return matches
+
+    def delete_document(self, document_id: str) -> int:
+        with self._lock:
+            keep_indices = [
+                index
+                for index, mapping in enumerate(self._mappings)
+                if mapping.document_id != document_id
+            ]
+            removed = len(self._mappings) - len(keep_indices)
+            if removed == 0:
+                return 0
+
+            new_index = faiss.IndexFlatIP(self._dimensions)
+            if keep_indices:
+                vectors = np.vstack(
+                    [
+                        cast(NDArray[np.float32], self._index.reconstruct(index))
+                        for index in keep_indices
+                    ]
+                ).astype(np.float32)
+                new_index.add(vectors)
+            self._index = new_index
+            self._mappings = [self._mappings[index] for index in keep_indices]
+            self._persist()
+            return removed
+
+    def _matrix(self, vectors: list[list[float]]) -> NDArray[np.float32]:
+        matrix = np.asarray(vectors, dtype=np.float32)
+        if matrix.ndim != 2 or matrix.shape[1] != self._dimensions:
+            raise ValueError(
+                f"vectors must have {self._dimensions} dimensions; got {matrix.shape}"
+            )
+        norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+        if np.any(norms == 0):
+            raise ValueError("zero vectors cannot be indexed")
+        return cast(NDArray[np.float32], matrix / norms)
+
+    def _load_if_present(self) -> None:
+        present = [
+            self._index_path.exists(),
+            self._mapping_path.exists(),
+            self._manifest_path.exists(),
+        ]
+        if not any(present):
+            return
+        if not all(present):
+            raise IncompatibleIndexError("vector index files are incomplete")
+
+        manifest = json.loads(self._manifest_path.read_text(encoding="utf-8"))
+        if manifest != {
+            "model_name": self._model_name,
+            "dimensions": self._dimensions,
+            "metric": "cosine",
+        }:
+            raise IncompatibleIndexError("vector index model configuration is incompatible")
+
+        raw_mappings = json.loads(self._mapping_path.read_text(encoding="utf-8"))
+        self._mappings = [
+            _Mapping(
+                chunk_id=str(item["chunk_id"]),
+                document_id=str(item["document_id"]),
+            )
+            for item in raw_mappings
+        ]
+        self._index = faiss.read_index(str(self._index_path))
+        if self._index.d != self._dimensions:
+            raise IncompatibleIndexError("stored FAISS dimensions are incompatible")
+        if self._index.ntotal != len(self._mappings):
+            raise IncompatibleIndexError("vector mapping count does not match FAISS index")
+
+    def _persist(self) -> None:
+        temporary_index = self._path / "index.tmp.faiss"
+        temporary_mapping = self._path / "mapping.tmp.json"
+        temporary_manifest = self._path / "manifest.tmp.json"
+
+        faiss.write_index(self._index, str(temporary_index))
+        temporary_mapping.write_text(
+            json.dumps([asdict(mapping) for mapping in self._mappings], indent=2),
+            encoding="utf-8",
+        )
+        temporary_manifest.write_text(
+            json.dumps(
+                {
+                    "model_name": self._model_name,
+                    "dimensions": self._dimensions,
+                    "metric": "cosine",
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        os.replace(temporary_index, self._index_path)
+        os.replace(temporary_mapping, self._mapping_path)
+        os.replace(temporary_manifest, self._manifest_path)

--- a/tests/embeddings/test_mixedbread.py
+++ b/tests/embeddings/test_mixedbread.py
@@ -1,0 +1,54 @@
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+from doc2knowledge.embeddings.mixedbread import MixedbreadEmbeddingService
+
+
+class FakeEncoder:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def encode(
+        self,
+        sentences: str | Sequence[str],
+        **kwargs: Any,
+    ) -> np.ndarray:
+        self.calls.append({"sentences": sentences, **kwargs})
+        if isinstance(sentences, str):
+            return np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        return np.array(
+            [[1.0, 0.0, 0.0] for _ in sentences],
+            dtype=np.float32,
+        )
+
+
+def test_model_is_lazy_reused_and_query_uses_retrieval_prompt() -> None:
+    encoder = FakeEncoder()
+    factory_calls: list[tuple[str, int]] = []
+
+    def factory(model_name: str, dimensions: int) -> FakeEncoder:
+        factory_calls.append((model_name, dimensions))
+        return encoder
+
+    service = MixedbreadEmbeddingService(
+        model_name="mixedbread-ai/mxbai-embed-large-v1",
+        dimensions=3,
+        model_factory=factory,
+    )
+
+    assert factory_calls == []
+    assert service.embed_documents(["alpha", "beta"]) == [
+        [1.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+    ]
+    assert service.embed_query("question") == [1.0, 0.0, 0.0]
+    assert factory_calls == [("mixedbread-ai/mxbai-embed-large-v1", 3)]
+
+    document_call, query_call = encoder.calls
+    assert "prompt_name" not in document_call
+    assert query_call["prompt_name"] == "query"
+    assert document_call["normalize_embeddings"] is True
+    assert query_call["normalize_embeddings"] is True
+    assert service.dimensions == 3

--- a/tests/storage/test_vectors.py
+++ b/tests/storage/test_vectors.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+from doc2knowledge.storage.vectors import (
+    IncompatibleIndexError,
+    VectorRecord,
+    VectorRepository,
+)
+
+
+def test_vector_repository_persists_searches_filters_and_deletes(tmp_path: Path) -> None:
+    repository = VectorRepository(
+        tmp_path / "vectors",
+        model_name="test-model",
+        dimensions=3,
+    )
+    repository.add(
+        [
+            VectorRecord("c1", "d1", [1.0, 0.0, 0.0]),
+            VectorRecord("c2", "d2", [0.8, 0.2, 0.0]),
+            VectorRecord("c3", "d2", [0.0, 1.0, 0.0]),
+        ]
+    )
+
+    assert [match.chunk_id for match in repository.search([1.0, 0.0, 0.0], 2)] == [
+        "c1",
+        "c2",
+    ]
+    assert [
+        match.chunk_id
+        for match in repository.search(
+            [1.0, 0.0, 0.0],
+            2,
+            document_ids={"d2"},
+        )
+    ] == ["c2", "c3"]
+
+    reopened = VectorRepository(
+        tmp_path / "vectors",
+        model_name="test-model",
+        dimensions=3,
+    )
+    assert [match.chunk_id for match in reopened.search([0.0, 1.0, 0.0], 1)] == ["c3"]
+
+    assert reopened.delete_document("d2") == 2
+    assert [match.chunk_id for match in reopened.search([1.0, 0.0, 0.0], 5)] == ["c1"]
+    assert reopened.delete_document("missing") == 0
+
+
+def test_vector_repository_rejects_incompatible_or_invalid_vectors(tmp_path: Path) -> None:
+    path = tmp_path / "vectors"
+    repository = VectorRepository(path, model_name="test-model", dimensions=3)
+
+    with pytest.raises(ValueError, match="dimensions"):
+        repository.add([VectorRecord("c1", "d1", [1.0, 0.0])])
+
+    repository.add([VectorRecord("c1", "d1", [1.0, 0.0, 0.0])])
+
+    with pytest.raises(IncompatibleIndexError):
+        VectorRepository(path, model_name="different-model", dimensions=3)
+
+    with pytest.raises(IncompatibleIndexError):
+        VectorRepository(path, model_name="test-model", dimensions=2)


### PR DESCRIPTION
## Summary

Introduces the embedding and vector-storage boundary without yet coupling it to HTTP retrieval.

## Embeddings

- default model: `mixedbread-ai/mxbai-embed-large-v1`
- lazy, process-reused SentenceTransformer instance
- configurable Matryoshka dimensions (default 1024)
- normalized document vectors
- retrieval-specific `prompt_name="query"` only for queries
- injectable model factory for deterministic, download-free CI tests

## Vector storage

- one persistent FAISS cosine-similarity collection for all chunks
- explicit chunk/document mapping
- metadata filtering at search time
- restart persistence
- document deletion through deterministic index rebuild
- manifest validation for model/dimension incompatibility
- atomic file replacement during persistence

## Stack

Targets `feat/document-ingestion` and should merge after PR #6. Actual ingestion indexing and `/search` are intentionally left to the next PR.