### PR TITLE
feat: add Gemma grounded answers with validated citations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ module = [
     "sentence_transformers.*",
 ]
 ignore_missing_imports = true
+follow_imports = "skip"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "beautifulsoup4>=4.12,<5",
     "faiss-cpu>=1.8,<2",
     "fastapi>=0.115,<1",
+    "google-genai>=1.0,<2",
     "numpy>=1.26,<3",
     "pydantic-settings>=2.6,<3",
     "pypdf>=5.1,<6",
@@ -52,7 +53,14 @@ strict = true
 packages = ["doc2knowledge"]
 
 [[tool.mypy.overrides]]
-module = ["faiss", "faiss.*", "sentence_transformers", "sentence_transformers.*"]
+module = [
+    "faiss",
+    "faiss.*",
+    "google",
+    "google.*",
+    "sentence_transformers",
+    "sentence_transformers.*",
+]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/doc2knowledge/api.py
+++ b/src/doc2knowledge/api.py
@@ -6,9 +6,12 @@ from doc2knowledge import __version__
 from doc2knowledge.config import Settings
 from doc2knowledge.embeddings.base import EmbeddingService
 from doc2knowledge.embeddings.mixedbread import MixedbreadEmbeddingService
+from doc2knowledge.generation.base import GenerationService
+from doc2knowledge.generation.gemma import GemmaGenerationService
 from doc2knowledge.ingestion.service import IngestionService
 from doc2knowledge.retrieval.service import RetrievalService
 from doc2knowledge.routes.documents import router as documents_router
+from doc2knowledge.routes.query import router as query_router
 from doc2knowledge.routes.search import router as search_router
 from doc2knowledge.storage.metadata import MetadataRepository
 from doc2knowledge.storage.vectors import VectorRepository
@@ -19,6 +22,7 @@ def create_app(
     *,
     embedding_service: EmbeddingService | None = None,
     vector_repository: VectorRepository | None = None,
+    generation_service: GenerationService | None = None,
 ) -> FastAPI:
     """Create a configured FastAPI application."""
 
@@ -32,6 +36,14 @@ def create_app(
         resolved_settings.data_dir / "vectors",
         model_name=embeddings.model_name,
         dimensions=embeddings.dimensions,
+    )
+    generation = generation_service or GemmaGenerationService(
+        api_key=(
+            resolved_settings.gemini_api_key.get_secret_value()
+            if resolved_settings.gemini_api_key is not None
+            else None
+        ),
+        model_name=resolved_settings.llm_model,
     )
     ingestion_service = IngestionService(
         metadata,
@@ -53,8 +65,10 @@ def create_app(
     app.state.vector_repository = vectors
     app.state.ingestion_service = ingestion_service
     app.state.retrieval_service = retrieval_service
+    app.state.generation_service = generation
     app.include_router(documents_router)
     app.include_router(search_router)
+    app.include_router(query_router)
 
     @app.get("/health", tags=["system"])
     def health() -> dict[str, str]:

--- a/src/doc2knowledge/generation/__init__.py
+++ b/src/doc2knowledge/generation/__init__.py
@@ -1,0 +1,1 @@
+"""Grounded answer generation adapters."""

--- a/src/doc2knowledge/generation/base.py
+++ b/src/doc2knowledge/generation/base.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from doc2knowledge.domain import Answer, RetrievedChunk
+
+
+class GenerationService(ABC):
+    @abstractmethod
+    def generate(self, question: str, evidence: list[RetrievedChunk]) -> Answer:
+        """Generate an answer grounded in the supplied evidence."""

--- a/src/doc2knowledge/generation/gemma.py
+++ b/src/doc2knowledge/generation/gemma.py
@@ -66,9 +66,7 @@ class GemmaGenerationService(GenerationService):
                 evidence=[],
             )
         if not self._api_key:
-            raise GenerationNotConfiguredError(
-                "GEMINI_API_KEY is required for generated answers"
-            )
+            raise GenerationNotConfiguredError("GEMINI_API_KEY is required for generated answers")
 
         prompt, sources = build_grounded_prompt(question, evidence)
         try:
@@ -89,7 +87,9 @@ class GemmaGenerationService(GenerationService):
         try:
             citations = resolve_citations(text, sources)
         except InvalidCitationError as error:
-            raise GenerationProviderError("generated answer contained an invalid citation") from error
+            raise GenerationProviderError(
+                "generated answer contained an invalid citation"
+            ) from error
 
         abstention = "not enough evidence" in text.lower()
         if not citations and not abstention:

--- a/src/doc2knowledge/generation/gemma.py
+++ b/src/doc2knowledge/generation/gemma.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from threading import Lock
+from typing import Any, Protocol, cast
+
+from doc2knowledge.domain import Answer, RetrievedChunk
+from doc2knowledge.generation.base import GenerationService
+from doc2knowledge.generation.prompt import (
+    InvalidCitationError,
+    build_grounded_prompt,
+    resolve_citations,
+)
+
+
+class GenerationNotConfiguredError(RuntimeError):
+    pass
+
+
+class GenerationProviderError(RuntimeError):
+    pass
+
+
+class ResponseLike(Protocol):
+    text: str | None
+
+
+class ModelsLike(Protocol):
+    def generate_content(self, **kwargs: Any) -> ResponseLike: ...
+
+
+class ClientLike(Protocol):
+    models: ModelsLike
+
+
+ClientFactory = Callable[[str], ClientLike]
+
+
+def _default_client_factory(api_key: str) -> ClientLike:
+    from google import genai
+
+    return cast(ClientLike, genai.Client(api_key=api_key))
+
+
+class GemmaGenerationService(GenerationService):
+    """Generate citation-grounded answers with Gemma through the Gemini API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None,
+        model_name: str,
+        client_factory: ClientFactory = _default_client_factory,
+    ) -> None:
+        self._api_key = api_key
+        self._model_name = model_name
+        self._client_factory = client_factory
+        self._client: ClientLike | None = None
+        self._client_lock = Lock()
+
+    def generate(self, question: str, evidence: list[RetrievedChunk]) -> Answer:
+        if not evidence:
+            return Answer(
+                text="There is not enough evidence in the indexed documents to answer.",
+                citations=[],
+                evidence=[],
+            )
+        if not self._api_key:
+            raise GenerationNotConfiguredError(
+                "GEMINI_API_KEY is required for generated answers"
+            )
+
+        prompt, sources = build_grounded_prompt(question, evidence)
+        try:
+            response = self._get_client().models.generate_content(
+                model=self._model_name,
+                contents=prompt,
+                config={
+                    "temperature": 0.1,
+                    "max_output_tokens": 1024,
+                },
+            )
+        except Exception as error:
+            raise GenerationProviderError("generation provider request failed") from error
+
+        text = (response.text or "").strip()
+        if not text:
+            raise GenerationProviderError("generation provider returned an empty response")
+        try:
+            citations = resolve_citations(text, sources)
+        except InvalidCitationError as error:
+            raise GenerationProviderError("generated answer contained an invalid citation") from error
+
+        abstention = "not enough evidence" in text.lower()
+        if not citations and not abstention:
+            raise GenerationProviderError("generated answer did not cite supplied evidence")
+        return Answer(text=text, citations=citations, evidence=evidence)
+
+    def _get_client(self) -> ClientLike:
+        if self._client is None:
+            with self._client_lock:
+                if self._client is None:
+                    if not self._api_key:
+                        raise GenerationNotConfiguredError(
+                            "GEMINI_API_KEY is required for generated answers"
+                        )
+                    self._client = self._client_factory(self._api_key)
+        return cast(ClientLike, self._client)

--- a/src/doc2knowledge/generation/prompt.py
+++ b/src/doc2knowledge/generation/prompt.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import re
+
+from doc2knowledge.domain import Citation, RetrievedChunk
+
+
+class InvalidCitationError(ValueError):
+    pass
+
+
+_SOURCE_PATTERN = re.compile(r"\[(S\d+)]")
+
+
+def build_grounded_prompt(
+    question: str,
+    evidence: list[RetrievedChunk],
+) -> tuple[str, dict[str, RetrievedChunk]]:
+    sources = {f"S{index}": result for index, result in enumerate(evidence, start=1)}
+    source_blocks: list[str] = []
+    for label, result in sources.items():
+        location = [result.document.filename]
+        if result.chunk.source_page is not None:
+            location.append(f"page {result.chunk.source_page}")
+        if result.chunk.section:
+            location.append(f"section {result.chunk.section}")
+        source_blocks.append(
+            f"[{label}] {' | '.join(location)}\n{result.chunk.text.strip()}"
+        )
+
+    prompt = "\n\n".join(
+        [
+            "You are a careful document research assistant.",
+            (
+                "Answer only from the supplied sources. Cite every factual claim with one or "
+                "more source labels such as [S1]. Do not invent sources or use outside "
+                "knowledge. If the sources do not support an answer, say exactly: "
+                '"There is not enough evidence in the indexed documents to answer."'
+            ),
+            "Sources:\n" + ("\n\n".join(source_blocks) or "(none)"),
+            f"Question: {question.strip()}",
+            "Answer:",
+        ]
+    )
+    return prompt, sources
+
+
+def resolve_citations(
+    answer_text: str,
+    sources: dict[str, RetrievedChunk],
+) -> list[Citation]:
+    labels: list[str] = []
+    for label in _SOURCE_PATTERN.findall(answer_text):
+        if label not in sources:
+            raise InvalidCitationError(f"answer referenced unknown source label {label}")
+        if label not in labels:
+            labels.append(label)
+
+    return [
+        Citation(
+            label=label,
+            document_id=sources[label].document.id,
+            filename=sources[label].document.filename,
+            chunk_id=sources[label].chunk.id,
+            source_page=sources[label].chunk.source_page,
+            section=sources[label].chunk.section,
+        )
+        for label in labels
+    ]

--- a/src/doc2knowledge/generation/prompt.py
+++ b/src/doc2knowledge/generation/prompt.py
@@ -24,9 +24,7 @@ def build_grounded_prompt(
             location.append(f"page {result.chunk.source_page}")
         if result.chunk.section:
             location.append(f"section {result.chunk.section}")
-        source_blocks.append(
-            f"[{label}] {' | '.join(location)}\n{result.chunk.text.strip()}"
-        )
+        source_blocks.append(f"[{label}] {' | '.join(location)}\n{result.chunk.text.strip()}")
 
     prompt = "\n\n".join(
         [

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Annotated, cast
 
-from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
+from fastapi import (
+    APIRouter,
+    File,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
 from pydantic import BaseModel, ConfigDict
 
 from doc2knowledge.domain import Document, DocumentStatus
@@ -94,12 +102,16 @@ def list_documents(request: Request) -> list[DocumentResponse]:
 def get_document(document_id: str, request: Request) -> DocumentResponse:
     document = _service(request).get_document(document_id)
     if document is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
+        )
     return _response(document)
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_document(document_id: str, request: Request) -> Response:
     if not _service(request).delete_document(document_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
+        )
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -102,16 +102,12 @@ def list_documents(request: Request) -> list[DocumentResponse]:
 def get_document(document_id: str, request: Request) -> DocumentResponse:
     document = _service(request).get_document(document_id)
     if document is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
     return _response(document)
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_document(document_id: str, request: Request) -> Response:
     if not _service(request).delete_document(document_id):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import cast
+from typing import Annotated, cast
 
 from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
 from pydantic import BaseModel, ConfigDict
@@ -47,7 +47,7 @@ def _response(document: Document) -> DocumentResponse:
 async def upload_document(
     request: Request,
     response: Response,
-    file: UploadFile = File(...),
+    file: Annotated[UploadFile, File()],
 ) -> UploadResponse:
     data = await file.read()
     try:

--- a/src/doc2knowledge/routes/query.py
+++ b/src/doc2knowledge/routes/query.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import cast
+
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, Field, field_validator
+
+from doc2knowledge.config import Settings
+from doc2knowledge.domain import Answer, Citation
+from doc2knowledge.generation.base import GenerationService
+from doc2knowledge.generation.gemma import (
+    GenerationNotConfiguredError,
+    GenerationProviderError,
+)
+from doc2knowledge.retrieval.service import RetrievalService
+from doc2knowledge.routes.search import EvidenceResponse, evidence_response
+
+router = APIRouter(tags=["generation"])
+
+
+class QueryRequest(BaseModel):
+    question: str
+    top_k: int | None = Field(default=None, ge=1, le=50)
+    document_ids: list[str] | None = None
+
+    @field_validator("question")
+    @classmethod
+    def question_must_not_be_blank(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("question must not be blank")
+        return normalized
+
+
+class CitationResponse(BaseModel):
+    label: str
+    document_id: str
+    filename: str
+    chunk_id: str
+    source_page: int | None
+    section: str | None
+
+
+class QueryResponse(BaseModel):
+    answer: str
+    citations: list[CitationResponse]
+    evidence: list[EvidenceResponse]
+
+
+def _retrieval(request: Request) -> RetrievalService:
+    return cast(RetrievalService, request.app.state.retrieval_service)
+
+
+def _generation(request: Request) -> GenerationService:
+    return cast(GenerationService, request.app.state.generation_service)
+
+
+def _settings(request: Request) -> Settings:
+    return cast(Settings, request.app.state.settings)
+
+
+def _citation_response(citation: Citation) -> CitationResponse:
+    return CitationResponse(
+        label=citation.label,
+        document_id=citation.document_id,
+        filename=citation.filename,
+        chunk_id=citation.chunk_id,
+        source_page=citation.source_page,
+        section=citation.section,
+    )
+
+
+def _query_response(answer: Answer) -> QueryResponse:
+    return QueryResponse(
+        answer=answer.text,
+        citations=[_citation_response(citation) for citation in answer.citations],
+        evidence=[evidence_response(result) for result in answer.evidence],
+    )
+
+
+@router.post("/query", response_model=QueryResponse)
+def query_documents(payload: QueryRequest, request: Request) -> QueryResponse:
+    evidence = _retrieval(request).search(
+        payload.question,
+        top_k=payload.top_k or _settings(request).top_k,
+        document_ids=set(payload.document_ids) if payload.document_ids else None,
+    )
+    try:
+        answer = _generation(request).generate(payload.question, evidence)
+    except GenerationNotConfiguredError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"code": "generation_not_configured", "message": str(error)},
+        ) from error
+    except GenerationProviderError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"code": "generation_provider_error", "message": str(error)},
+        ) from error
+    return _query_response(answer)

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from doc2knowledge.api import create_app
+from doc2knowledge.config import Settings
+from doc2knowledge.domain import Answer, Citation, RetrievedChunk
+from doc2knowledge.generation.base import GenerationService
+from doc2knowledge.generation.gemma import GenerationNotConfiguredError
+from tests.fakes import FakeEmbeddingService
+
+
+class FakeGenerationService(GenerationService):
+    def generate(self, question: str, evidence: list[RetrievedChunk]) -> Answer:
+        if not evidence:
+            return Answer("There is not enough evidence to answer.", [], [])
+        first = evidence[0]
+        return Answer(
+            text=f"Alpha answer [S1] for {question}",
+            citations=[
+                Citation(
+                    label="S1",
+                    document_id=first.document.id,
+                    filename=first.document.filename,
+                    chunk_id=first.chunk.id,
+                    source_page=first.chunk.source_page,
+                    section=first.chunk.section,
+                )
+            ],
+            evidence=evidence,
+        )
+
+
+class UnconfiguredGenerationService(GenerationService):
+    def generate(self, question: str, evidence: list[RetrievedChunk]) -> Answer:
+        raise GenerationNotConfiguredError("missing key")
+
+
+def make_client(
+    tmp_path: Path,
+    generation_service: GenerationService,
+) -> TestClient:
+    return TestClient(
+        create_app(
+            Settings(
+                data_dir=tmp_path,
+                embedding_model="test-model",
+                embedding_dimensions=3,
+            ),
+            embedding_service=FakeEmbeddingService(),
+            generation_service=generation_service,
+        )
+    )
+
+
+def test_query_returns_grounded_answer_citations_and_evidence(tmp_path: Path) -> None:
+    client = make_client(tmp_path, FakeGenerationService())
+    uploaded = client.post(
+        "/documents",
+        files={"file": ("alpha.txt", b"alpha evidence", "text/plain")},
+    ).json()["document"]
+
+    response = client.post("/query", json={"question": "What is Alpha?", "top_k": 1})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["answer"] == "Alpha answer [S1] for What is Alpha?"
+    assert body["citations"][0]["filename"] == "alpha.txt"
+    assert body["citations"][0]["document_id"] == uploaded["id"]
+    assert body["evidence"][0]["text"] == "alpha evidence"
+
+
+def test_query_abstains_when_no_documents_are_indexed(tmp_path: Path) -> None:
+    client = make_client(tmp_path, FakeGenerationService())
+
+    response = client.post("/query", json={"question": "What is missing?"})
+
+    assert response.status_code == 200
+    assert "not enough evidence" in response.json()["answer"].lower()
+    assert response.json()["citations"] == []
+    assert response.json()["evidence"] == []
+
+
+def test_query_reports_unconfigured_generation(tmp_path: Path) -> None:
+    client = make_client(tmp_path, UnconfiguredGenerationService())
+
+    response = client.post("/query", json={"question": "What is Alpha?"})
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "generation_not_configured"
+
+
+def test_query_rejects_blank_question(tmp_path: Path) -> None:
+    client = make_client(tmp_path, FakeGenerationService())
+
+    response = client.post("/query", json={"question": "   "})
+
+    assert response.status_code == 422

--- a/tests/generation/test_gemma.py
+++ b/tests/generation/test_gemma.py
@@ -83,6 +83,24 @@ def test_generation_abstains_without_evidence_without_calling_provider() -> None
     assert models.calls == []
 
 
+def test_generation_rejects_uncited_or_invented_sources() -> None:
+    uncited = GemmaGenerationService(
+        api_key="secret",
+        model_name="gemma-4-31b-it",
+        client_factory=lambda api_key: FakeClient(FakeModels("Alpha was founded in 2020.")),
+    )
+    invented = GemmaGenerationService(
+        api_key="secret",
+        model_name="gemma-4-31b-it",
+        client_factory=lambda api_key: FakeClient(FakeModels("Unsupported claim [S9].")),
+    )
+
+    with pytest.raises(GenerationProviderError, match="did not cite"):
+        uncited.generate("question", evidence())
+    with pytest.raises(GenerationProviderError, match="invalid citation"):
+        invented.generate("question", evidence())
+
+
 def test_missing_key_and_provider_failures_are_explicit() -> None:
     unconfigured = GemmaGenerationService(
         api_key=None,

--- a/tests/generation/test_gemma.py
+++ b/tests/generation/test_gemma.py
@@ -1,0 +1,111 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from doc2knowledge.domain import Chunk, Document, DocumentStatus, RetrievedChunk
+from doc2knowledge.generation.gemma import (
+    GemmaGenerationService,
+    GenerationNotConfiguredError,
+    GenerationProviderError,
+)
+
+
+class FakeModels:
+    def __init__(self, text: str | None = "Alpha was founded in 2020 [S1].") -> None:
+        self.text = text
+        self.calls: list[dict[str, Any]] = []
+        self.error: Exception | None = None
+
+    def generate_content(self, **kwargs: Any) -> SimpleNamespace:
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return SimpleNamespace(text=self.text)
+
+
+class FakeClient:
+    def __init__(self, models: FakeModels) -> None:
+        self.models = models
+
+
+def evidence() -> list[RetrievedChunk]:
+    return [
+        RetrievedChunk(
+            chunk=Chunk("c1", "d1", 0, "Alpha was founded in 2020.", 3, "History"),
+            document=Document(
+                "d1",
+                "alpha.txt",
+                "text/plain",
+                "h1",
+                DocumentStatus.READY,
+                datetime(2026, 7, 11, tzinfo=UTC),
+                1,
+                None,
+            ),
+            score=0.9,
+        )
+    ]
+
+
+def test_generation_uses_configured_gemma_model_and_resolves_citations() -> None:
+    models = FakeModels()
+    service = GemmaGenerationService(
+        api_key="secret",
+        model_name="gemma-4-31b-it",
+        client_factory=lambda api_key: FakeClient(models),
+    )
+
+    answer = service.generate("When was Alpha founded?", evidence())
+
+    assert answer.text == "Alpha was founded in 2020 [S1]."
+    assert [citation.label for citation in answer.citations] == ["S1"]
+    assert answer.evidence == evidence()
+    assert models.calls[0]["model"] == "gemma-4-31b-it"
+    assert "When was Alpha founded?" in models.calls[0]["contents"]
+    assert models.calls[0]["config"]["temperature"] == 0.1
+
+
+def test_generation_abstains_without_evidence_without_calling_provider() -> None:
+    models = FakeModels()
+    service = GemmaGenerationService(
+        api_key="secret",
+        model_name="gemma-4-31b-it",
+        client_factory=lambda api_key: FakeClient(models),
+    )
+
+    answer = service.generate("Unknown?", [])
+
+    assert "not enough evidence" in answer.text.lower()
+    assert answer.citations == []
+    assert answer.evidence == []
+    assert models.calls == []
+
+
+def test_missing_key_and_provider_failures_are_explicit() -> None:
+    unconfigured = GemmaGenerationService(
+        api_key=None,
+        model_name="gemma-4-31b-it",
+        client_factory=lambda api_key: FakeClient(FakeModels()),
+    )
+    with pytest.raises(GenerationNotConfiguredError):
+        unconfigured.generate("question", evidence())
+
+    models = FakeModels()
+    models.error = RuntimeError("quota")
+    failing = GemmaGenerationService(
+        api_key="secret",
+        model_name="gemma-4-31b-it",
+        client_factory=lambda api_key: FakeClient(models),
+    )
+    with pytest.raises(GenerationProviderError, match="provider request failed"):
+        failing.generate("question", evidence())
+
+    empty_response = GemmaGenerationService(
+        api_key="secret",
+        model_name="gemma-4-31b-it",
+        client_factory=lambda api_key: FakeClient(FakeModels(text=None)),
+    )
+    with pytest.raises(GenerationProviderError, match="empty response"):
+        empty_response.generate("question", evidence())

--- a/tests/generation/test_prompt.py
+++ b/tests/generation/test_prompt.py
@@ -1,0 +1,72 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from doc2knowledge.domain import Chunk, Document, DocumentStatus, RetrievedChunk
+from doc2knowledge.generation.prompt import (
+    InvalidCitationError,
+    build_grounded_prompt,
+    resolve_citations,
+)
+
+
+def evidence() -> list[RetrievedChunk]:
+    now = datetime(2026, 7, 11, tzinfo=UTC)
+    return [
+        RetrievedChunk(
+            chunk=Chunk("c1", "d1", 0, "Alpha was founded in 2020.", 3, "History"),
+            document=Document(
+                "d1",
+                "alpha.txt",
+                "text/plain",
+                "h1",
+                DocumentStatus.READY,
+                now,
+                1,
+                None,
+            ),
+            score=0.93,
+        ),
+        RetrievedChunk(
+            chunk=Chunk("c2", "d2", 0, "Beta launched in 2022.", None, None),
+            document=Document(
+                "d2",
+                "beta.txt",
+                "text/plain",
+                "h2",
+                DocumentStatus.READY,
+                now,
+                1,
+                None,
+            ),
+            score=0.81,
+        ),
+    ]
+
+
+def test_prompt_assigns_stable_labels_and_requires_grounding() -> None:
+    prompt, sources = build_grounded_prompt("When was Alpha founded?", evidence())
+
+    assert "Answer only from the supplied sources" in prompt
+    assert "[S1] alpha.txt | page 3 | section History" in prompt
+    assert "[S2] beta.txt" in prompt
+    assert "Question: When was Alpha founded?" in prompt
+    assert list(sources) == ["S1", "S2"]
+
+
+def test_citations_are_resolved_once_in_answer_order() -> None:
+    _, sources = build_grounded_prompt("question", evidence())
+
+    citations = resolve_citations("Alpha was founded in 2020 [S1]. See [S1] and [S2].", sources)
+
+    assert [citation.label for citation in citations] == ["S1", "S2"]
+    assert citations[0].filename == "alpha.txt"
+    assert citations[0].source_page == 3
+    assert citations[1].chunk_id == "c2"
+
+
+def test_unknown_source_label_is_rejected() -> None:
+    _, sources = build_grounded_prompt("question", evidence())
+
+    with pytest.raises(InvalidCitationError, match="S9"):
+        resolve_citations("Unsupported claim [S9].", sources)


### PR DESCRIPTION
Superseded by clean replacement PR #14, rebuilt directly from verified `main`. The replacement also fixed a strict-mypy issue and a citation-validation bypass where mixed uncited answers containing the phrase "not enough evidence" were accepted. PR #14 passed lint, formatting, mypy, 29 tests with coverage, package build, and Docker build before merging.