### PR TITLE
feat: add bounded processing and request observability

### DIFF
--- a/src/doc2knowledge/api.py
+++ b/src/doc2knowledge/api.py
@@ -9,6 +9,7 @@ from doc2knowledge.embeddings.mixedbread import MixedbreadEmbeddingService
 from doc2knowledge.generation.base import GenerationService
 from doc2knowledge.generation.gemma import GemmaGenerationService
 from doc2knowledge.ingestion.service import IngestionService
+from doc2knowledge.observability import install_request_observability
 from doc2knowledge.retrieval.service import RetrievalService
 from doc2knowledge.routes.documents import router as documents_router
 from doc2knowledge.routes.query import router as query_router
@@ -59,6 +60,7 @@ def create_app(
         version=__version__,
         description="Document ingestion, retrieval, and grounded question answering.",
     )
+    install_request_observability(app)
     app.state.settings = resolved_settings
     app.state.metadata_repository = metadata
     app.state.embedding_service = embeddings
@@ -66,6 +68,7 @@ def create_app(
     app.state.ingestion_service = ingestion_service
     app.state.retrieval_service = retrieval_service
     app.state.generation_service = generation
+    app.state.processing_limiter = None
     app.include_router(documents_router)
     app.include_router(search_router)
     app.include_router(query_router)
@@ -76,6 +79,18 @@ def create_app(
             "status": "ok",
             "service": "doc2knowledge",
             "version": __version__,
+        }
+
+    @app.get("/ready", tags=["system"])
+    def ready() -> dict[str, str | int | bool]:
+        return {
+            "status": "ready",
+            "embedding_model": embeddings.model_name,
+            "embedding_dimensions": embeddings.dimensions,
+            "llm_model": resolved_settings.llm_model,
+            "generation_configured": resolved_settings.gemini_api_key is not None,
+            "processing_workers": resolved_settings.processing_workers,
+            "indexed_vectors": vectors.size,
         }
 
     return app

--- a/src/doc2knowledge/config.py
+++ b/src/doc2knowledge/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     llm_model: str = "gemma-4-31b-it"
     top_k: int = Field(default=6, ge=1, le=50)
     max_upload_bytes: int = Field(default=20 * 1024 * 1024, ge=1)
+    processing_workers: int = Field(default=2, ge=1, le=32)
     gemini_api_key: SecretStr | None = Field(
         default=None,
         validation_alias=AliasChoices(

--- a/src/doc2knowledge/observability.py
+++ b/src/doc2knowledge/observability.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from contextvars import ContextVar, Token
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from fastapi import FastAPI, Request, Response
+
+_REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_request_id: ContextVar[str | None] = ContextVar("request_id", default=None)
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        for field in ("request_id", "method", "path", "status_code", "duration_ms"):
+            value = getattr(record, field, None)
+            if value is not None:
+                payload[field] = value
+        return json.dumps(payload, separators=(",", ":"), default=str)
+
+
+def configure_logging() -> logging.Logger:
+    logger = logging.getLogger("doc2knowledge")
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    if not any(getattr(handler, "doc2knowledge_json", False) for handler in logger.handlers):
+        handler = logging.StreamHandler()
+        handler.setFormatter(JsonFormatter())
+        handler.doc2knowledge_json = True  # type: ignore[attr-defined]
+        logger.addHandler(handler)
+    return logger
+
+
+def current_request_id() -> str | None:
+    return _request_id.get()
+
+
+def _resolve_request_id(request: Request) -> str:
+    candidate = request.headers.get("X-Request-ID", "")
+    if _REQUEST_ID_PATTERN.fullmatch(candidate):
+        return candidate
+    return str(uuid4())
+
+
+def install_request_observability(app: FastAPI) -> None:
+    logger = configure_logging()
+
+    @app.middleware("http")
+    async def request_observability(request: Request, call_next: Any) -> Response:
+        request_id = _resolve_request_id(request)
+        token: Token[str | None] = _request_id.set(request_id)
+        started = time.perf_counter()
+        status_code = 500
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            response.headers["X-Request-ID"] = request_id
+            return response
+        finally:
+            duration_ms = round((time.perf_counter() - started) * 1000, 2)
+            logger.info(
+                "request_completed",
+                extra={
+                    "request_id": request_id,
+                    "method": request.method,
+                    "path": request.url.path,
+                    "status_code": status_code,
+                    "duration_ms": duration_ms,
+                },
+            )
+            _request_id.reset(token)

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -7,6 +7,7 @@ from anyio import CapacityLimiter, to_thread
 from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
 from pydantic import BaseModel, ConfigDict
 
+from doc2knowledge.config import Settings
 from doc2knowledge.domain import Document, DocumentStatus
 from doc2knowledge.ingestion.extractors import (
     EmptyDocumentError,
@@ -41,7 +42,12 @@ def _service(request: Request) -> IngestionService:
 
 
 def _limiter(request: Request) -> CapacityLimiter:
-    return cast(CapacityLimiter, request.app.state.processing_limiter)
+    limiter = request.app.state.processing_limiter
+    if limiter is None:
+        settings = cast(Settings, request.app.state.settings)
+        limiter = CapacityLimiter(settings.processing_workers)
+        request.app.state.processing_limiter = limiter
+    return cast(CapacityLimiter, limiter)
 
 
 def _response(document: Document) -> DocumentResponse:

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import cast
+from typing import Annotated, cast
 
 from anyio import CapacityLimiter, to_thread
 from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
@@ -58,7 +58,7 @@ def _response(document: Document) -> DocumentResponse:
 async def upload_document(
     request: Request,
     response: Response,
-    file: UploadFile = File(...),
+    file: Annotated[UploadFile, File()],
 ) -> UploadResponse:
     data = await file.read()
     try:

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -115,16 +115,12 @@ def list_documents(request: Request) -> list[DocumentResponse]:
 def get_document(document_id: str, request: Request) -> DocumentResponse:
     document = _service(request).get_document(document_id)
     if document is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
     return _response(document)
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_document(document_id: str, request: Request) -> Response:
     if not _service(request).delete_document(document_id):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -4,7 +4,15 @@ from datetime import datetime
 from typing import Annotated, cast
 
 from anyio import CapacityLimiter, to_thread
-from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
+from fastapi import (
+    APIRouter,
+    File,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
 from pydantic import BaseModel, ConfigDict
 
 from doc2knowledge.config import Settings
@@ -107,12 +115,16 @@ def list_documents(request: Request) -> list[DocumentResponse]:
 def get_document(document_id: str, request: Request) -> DocumentResponse:
     document = _service(request).get_document(document_id)
     if document is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
+        )
     return _response(document)
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_document(document_id: str, request: Request) -> Response:
     if not _service(request).delete_document(document_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
+        )
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import cast
 
+from anyio import CapacityLimiter, to_thread
 from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
 from pydantic import BaseModel, ConfigDict
 
@@ -39,6 +40,10 @@ def _service(request: Request) -> IngestionService:
     return cast(IngestionService, request.app.state.ingestion_service)
 
 
+def _limiter(request: Request) -> CapacityLimiter:
+    return cast(CapacityLimiter, request.app.state.processing_limiter)
+
+
 def _response(document: Document) -> DocumentResponse:
     return DocumentResponse.model_validate(document)
 
@@ -51,10 +56,12 @@ async def upload_document(
 ) -> UploadResponse:
     data = await file.read()
     try:
-        result = _service(request).ingest(
-            filename=file.filename or "document",
-            media_type=file.content_type or "application/octet-stream",
-            data=data,
+        result = await to_thread.run_sync(
+            _service(request).ingest,
+            file.filename or "document",
+            file.content_type or "application/octet-stream",
+            data,
+            limiter=_limiter(request),
         )
     except UploadTooLargeError as error:
         raise HTTPException(

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from doc2knowledge.api import create_app
+from doc2knowledge.config import Settings
+from tests.fakes import FakeEmbeddingService
+
+
+def test_readiness_reports_models_capacity_and_generation_state(tmp_path: Path) -> None:
+    client = TestClient(
+        create_app(
+            Settings(
+                data_dir=tmp_path,
+                embedding_model="test-model",
+                embedding_dimensions=3,
+                llm_model="gemma-4-31b-it",
+                processing_workers=2,
+            ),
+            embedding_service=FakeEmbeddingService(),
+        )
+    )
+
+    response = client.get("/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ready",
+        "embedding_model": "test-model",
+        "embedding_dimensions": 3,
+        "llm_model": "gemma-4-31b-it",
+        "generation_configured": False,
+        "processing_workers": 2,
+        "indexed_vectors": 0,
+    }
+    assert "api_key" not in response.text.lower()
+    assert "secret" not in response.text.lower()

--- a/tests/test_request_ids.py
+++ b/tests/test_request_ids.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from doc2knowledge.api import create_app
+from doc2knowledge.config import Settings
+from tests.fakes import FakeEmbeddingService
+
+
+def make_client(tmp_path: Path) -> TestClient:
+    return TestClient(
+        create_app(
+            Settings(
+                data_dir=tmp_path,
+                embedding_model="test-model",
+                embedding_dimensions=3,
+            ),
+            embedding_service=FakeEmbeddingService(),
+        )
+    )
+
+
+def test_request_id_is_generated_and_returned(tmp_path: Path) -> None:
+    response = make_client(tmp_path).get("/health")
+
+    request_id = response.headers["x-request-id"]
+    assert request_id
+    assert len(request_id) == 36
+
+
+def test_valid_caller_request_id_is_preserved(tmp_path: Path) -> None:
+    response = make_client(tmp_path).get(
+        "/health",
+        headers={"X-Request-ID": "client-request-123"},
+    )
+
+    assert response.headers["x-request-id"] == "client-request-123"
+
+
+def test_unsafe_request_id_is_replaced(tmp_path: Path) -> None:
+    response = make_client(tmp_path).get(
+        "/health",
+        headers={"X-Request-ID": "bad request id\nlog injection"},
+    )
+
+    assert response.headers["x-request-id"] != "bad request id\nlog injection"
+    assert len(response.headers["x-request-id"]) == 36

--- a/tests/test_request_ids.py
+++ b/tests/test_request_ids.py
@@ -38,10 +38,11 @@ def test_valid_caller_request_id_is_preserved(tmp_path: Path) -> None:
 
 
 def test_unsafe_request_id_is_replaced(tmp_path: Path) -> None:
+    unsafe_request_id = "bad request id"
     response = make_client(tmp_path).get(
         "/health",
-        headers={"X-Request-ID": "bad request id\nlog injection"},
+        headers={"X-Request-ID": unsafe_request_id},
     )
 
-    assert response.headers["x-request-id"] != "bad request id\nlog injection"
+    assert response.headers["x-request-id"] != unsafe_request_id
     assert len(response.headers["x-request-id"]) == 36


### PR DESCRIPTION
Superseded by clean replacement PR #15, rebuilt directly from verified `main`. The replacement fixed the lazy limiter race, bounded upload reads before full buffering, added atomic handling for concurrent identical uploads, removed project-owned Starlette status deprecations, and passed Ruff, strict mypy, 38 tests at 91.85% coverage, package build, and Docker build before merging.