### PR TITLE
feat: add retrieval evaluation harness and operating docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
 # doc2knowledge
 
-A document ingestion, retrieval, and evidence-grounded question-answering service.
+A local-first document ingestion, semantic retrieval, and evidence-grounded question-answering service.
 
-The project is being modernized in staged pull requests. The current foundation provides a packaged FastAPI application, typed configuration, health endpoint, repeatable development commands, Docker runtime, and CI checks.
+## Architecture
+
+- FastAPI application packaged under `src/doc2knowledge`
+- SQLite document and chunk metadata
+- one persistent FAISS collection across all documents
+- `mixedbread-ai/mxbai-embed-large-v1` document/query embeddings
+- configurable `gemma-4-31b-it` generation through the Gemini API
+- explicit citations resolved to document, chunk, page, and section metadata
 
 ## Requirements
 
 - Python 3.11+
 - Docker, optional
+- enough local memory to load the embedding model for real ingestion/search
+- a `GEMINI_API_KEY` created in Google AI Studio for `/query`
 
 ## Local development
 
@@ -21,20 +30,63 @@ The API starts on `http://localhost:8000`.
 
 ```bash
 curl http://localhost:8000/health
-```
-
-Expected response:
-
-```json
-{"status":"ok","service":"doc2knowledge","version":"0.1.0"}
+curl http://localhost:8000/ready
 ```
 
 ## Docker
 
 ```bash
 docker build -t doc2knowledge:local .
-docker run --rm -p 8000:8000 -v "$(pwd)/data:/app/data" doc2knowledge:local
+docker run --rm \
+  -p 8000:8000 \
+  -v "$(pwd)/data:/app/data" \
+  -v "$HOME/.cache/huggingface:/home/app/.cache/huggingface" \
+  -e GEMINI_API_KEY \
+  doc2knowledge:local
 ```
+
+The embedding model is loaded lazily on the first ingestion or search request. Persist the Hugging Face cache between container runs to avoid repeated downloads.
+
+## API workflow
+
+### Upload a document
+
+```bash
+curl -X POST http://localhost:8000/documents \
+  -F 'file=@notes.pdf'
+```
+
+Supported initial formats are PDF with extractable text, HTML, plain text, and Markdown. Uploads are content-hashed, deduplicated, chunked, embedded, and persisted.
+
+### Search evidence
+
+```bash
+curl -X POST http://localhost:8000/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"What does the document say about revenue?","top_k":6}'
+```
+
+`/search` does not require a Gemini API key. It returns ranked chunks with scores and source metadata.
+
+### Generate a cited answer
+
+```bash
+curl -X POST http://localhost:8000/query \
+  -H 'Content-Type: application/json' \
+  -d '{"question":"What does the document say about revenue?","top_k":6}'
+```
+
+The generation prompt contains only retrieved evidence. Non-abstaining answers must cite valid source labels such as `[S1]`; invalid or invented citations are rejected.
+
+### List and delete documents
+
+```bash
+curl http://localhost:8000/documents
+curl http://localhost:8000/documents/<document-id>
+curl -X DELETE http://localhost:8000/documents/<document-id>
+```
+
+Deletion removes the original file, metadata, chunks, and vectors.
 
 ## Configuration
 
@@ -48,13 +100,35 @@ Application settings use the `DOC2KNOWLEDGE_` prefix unless noted otherwise.
 | `DOC2KNOWLEDGE_LLM_MODEL` | `gemma-4-31b-it` |
 | `DOC2KNOWLEDGE_TOP_K` | `6` |
 | `DOC2KNOWLEDGE_MAX_UPLOAD_BYTES` | `20971520` |
+| `DOC2KNOWLEDGE_PROCESSING_WORKERS` | `2` |
 | `GEMINI_API_KEY` | unset |
 
-No API key or model download is required for the foundation test suite.
+The default test suite injects fake embedding and generation services. CI does not download models or call external APIs.
 
-## Roadmap
+## Retrieval evaluation
 
-See:
+1. Start the service and ingest the benchmark documents.
+2. Copy `eval/questions.example.json` and replace the questions and relevant filenames with your benchmark set.
+3. Run:
+
+```bash
+python scripts/evaluate_retrieval.py eval/questions.json --k 6
+```
+
+The command calls `/search` and prints mean recall@k and mean reciprocal rank. Keep the benchmark corpus and questions versioned so embedding, chunking, hybrid retrieval, and reranking changes can be compared instead of judged by vibes—the traditional enemy of retrieval engineering.
+
+## Development checks
+
+```bash
+ruff check .
+ruff format --check .
+mypy src
+pytest -q --cov=doc2knowledge --cov-report=term-missing
+python -m build
+docker build -t doc2knowledge:check .
+```
+
+## Design and implementation plan
 
 - `docs/superpowers/specs/2026-07-11-document-to-knowledge-modernization-design.md`
 - `docs/superpowers/plans/2026-07-11-document-to-knowledge-modernization.md`

--- a/eval/questions.example.json
+++ b/eval/questions.example.json
@@ -1,0 +1,12 @@
+{
+  "questions": [
+    {
+      "query": "When was Alpha founded?",
+      "relevant_filenames": ["alpha.txt"]
+    },
+    {
+      "query": "Which document discusses the Beta launch?",
+      "relevant_filenames": ["beta.txt"]
+    }
+  ]
+}

--- a/scripts/evaluate_retrieval.py
+++ b/scripts/evaluate_retrieval.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.error
+import urllib.request
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from doc2knowledge.evaluation import RankingCase, evaluate_rankings
+
+
+def search(base_url: str, query: str, top_k: int) -> tuple[str, ...]:
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}/search",
+        data=json.dumps({"query": query, "top_k": top_k}).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.URLError as error:
+        raise RuntimeError(f"search request failed: {error}") from error
+    return tuple(str(item["filename"]) for item in payload["evidence"])
+
+
+def load_cases(path: Path, base_url: str, top_k: int) -> list[RankingCase]:
+    payload: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    cases: list[RankingCase] = []
+    for item in payload["questions"]:
+        query = str(item["query"])
+        relevant = frozenset(str(value) for value in item["relevant_filenames"])
+        cases.append(
+            RankingCase(
+                query=query,
+                relevant_ids=relevant,
+                ranked_ids=search(base_url, query, top_k),
+            )
+        )
+    return cases
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Measure recall@k and MRR against a running doc2knowledge service."
+    )
+    parser.add_argument("questions", type=Path)
+    parser.add_argument("--base-url", default="http://localhost:8000")
+    parser.add_argument("--k", type=int, default=6)
+    args = parser.parse_args()
+
+    report = evaluate_rankings(
+        load_cases(args.questions, args.base_url, args.k),
+        k=args.k,
+    )
+    print(json.dumps(asdict(report), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/doc2knowledge/evaluation.py
+++ b/src/doc2knowledge/evaluation.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RankingCase:
+    query: str
+    relevant_ids: frozenset[str]
+    ranked_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class EvaluationReport:
+    query_count: int
+    k: int
+    recall_at_k: float
+    mean_reciprocal_rank: float
+
+
+def evaluate_rankings(cases: list[RankingCase], *, k: int) -> EvaluationReport:
+    if not cases:
+        raise ValueError("at least one ranking case is required")
+    if k < 1:
+        raise ValueError("k must be positive")
+    if any(not case.relevant_ids for case in cases):
+        raise ValueError("every ranking case must contain at least one relevant ID")
+
+    recalls: list[float] = []
+    reciprocal_ranks: list[float] = []
+    for case in cases:
+        top_k = case.ranked_ids[:k]
+        retrieved_relevant = len(case.relevant_ids.intersection(top_k))
+        recalls.append(retrieved_relevant / len(case.relevant_ids))
+
+        reciprocal_rank = 0.0
+        for rank, candidate in enumerate(case.ranked_ids, start=1):
+            if candidate in case.relevant_ids:
+                reciprocal_rank = 1.0 / rank
+                break
+        reciprocal_ranks.append(reciprocal_rank)
+
+    return EvaluationReport(
+        query_count=len(cases),
+        k=k,
+        recall_at_k=sum(recalls) / len(recalls),
+        mean_reciprocal_rank=sum(reciprocal_ranks) / len(reciprocal_ranks),
+    )

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import cast
+from typing import Annotated, cast
 
 from anyio import CapacityLimiter, to_thread
 from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
@@ -58,7 +58,7 @@ def _response(document: Document) -> DocumentResponse:
 async def upload_document(
     request: Request,
     response: Response,
-    file: UploadFile = File(...),
+    file: Annotated[UploadFile, File()],
 ) -> UploadResponse:
     data = await file.read()
     try:

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -115,16 +115,12 @@ def list_documents(request: Request) -> list[DocumentResponse]:
 def get_document(document_id: str, request: Request) -> DocumentResponse:
     document = _service(request).get_document(document_id)
     if document is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
     return _response(document)
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_document(document_id: str, request: Request) -> Response:
     if not _service(request).delete_document(document_id):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -4,7 +4,15 @@ from datetime import datetime
 from typing import Annotated, cast
 
 from anyio import CapacityLimiter, to_thread
-from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile, status
+from fastapi import (
+    APIRouter,
+    File,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
 from pydantic import BaseModel, ConfigDict
 
 from doc2knowledge.config import Settings
@@ -107,12 +115,16 @@ def list_documents(request: Request) -> list[DocumentResponse]:
 def get_document(document_id: str, request: Request) -> DocumentResponse:
     document = _service(request).get_document(document_id)
     if document is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
+        )
     return _response(document)
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_document(document_id: str, request: Request) -> Response:
     if not _service(request).delete_document(document_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="document not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="document not found"
+        )
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,43 @@
+import pytest
+
+from doc2knowledge.evaluation import RankingCase, evaluate_rankings
+
+
+def test_evaluation_reports_recall_at_k_and_mrr() -> None:
+    report = evaluate_rankings(
+        [
+            RankingCase(
+                query="alpha",
+                relevant_ids=frozenset({"a", "b"}),
+                ranked_ids=("a", "x", "b"),
+            ),
+            RankingCase(
+                query="beta",
+                relevant_ids=frozenset({"c"}),
+                ranked_ids=("x", "c", "y"),
+            ),
+        ],
+        k=2,
+    )
+
+    assert report.query_count == 2
+    assert report.k == 2
+    assert report.recall_at_k == pytest.approx(0.5)
+    assert report.mean_reciprocal_rank == pytest.approx(0.75)
+
+
+def test_evaluation_handles_no_results_and_validates_inputs() -> None:
+    report = evaluate_rankings(
+        [RankingCase("missing", frozenset({"a"}), ())],
+        k=5,
+    )
+
+    assert report.recall_at_k == 0.0
+    assert report.mean_reciprocal_rank == 0.0
+
+    with pytest.raises(ValueError, match="at least one"):
+        evaluate_rankings([], k=1)
+    with pytest.raises(ValueError, match="positive"):
+        evaluate_rankings([RankingCase("q", frozenset({"a"}), ())], k=0)
+    with pytest.raises(ValueError, match="relevant"):
+        evaluate_rankings([RankingCase("q", frozenset(), ())], k=1)


### PR DESCRIPTION
Superseded by clean replacement PR #16, rebuilt directly from the verified `main` branch after PR #15. The replacement corrected the old benchmark test's recall@2 expectation from 0.50 to the mathematically correct 0.75, made MRR consistently respect the k cutoff, added source-diversity reporting and stronger input/API validation, expanded operating documentation, and passed Ruff, strict mypy, 42 tests at 92.32% coverage, package build, and Docker build before merging.