### PR TITLE
feat: wire indexed ingestion and semantic search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,17 @@ jobs:
       - name: Type check
         run: mypy src
       - name: Test
-        run: pytest -q --cov=doc2knowledge --cov-report=term-missing
+        shell: bash
+        run: |
+          set -o pipefail
+          pytest -q --cov=doc2knowledge --cov-report=term-missing 2>&1 | tee pytest-output.txt
+      - name: Upload pytest output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-output
+          path: pytest-output.txt
+          if-no-files-found: ignore
       - name: Build package
         run: python -m build
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ follow_imports = "skip"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 addopts = "-ra --strict-markers"
 markers = [
     "integration: tests that may download models or use external services",

--- a/src/doc2knowledge/api.py
+++ b/src/doc2knowledge/api.py
@@ -4,21 +4,43 @@ from fastapi import FastAPI
 
 from doc2knowledge import __version__
 from doc2knowledge.config import Settings
+from doc2knowledge.embeddings.base import EmbeddingService
+from doc2knowledge.embeddings.mixedbread import MixedbreadEmbeddingService
 from doc2knowledge.ingestion.service import IngestionService
+from doc2knowledge.retrieval.service import RetrievalService
 from doc2knowledge.routes.documents import router as documents_router
+from doc2knowledge.routes.search import router as search_router
 from doc2knowledge.storage.metadata import MetadataRepository
+from doc2knowledge.storage.vectors import VectorRepository
 
 
-def create_app(settings: Settings | None = None) -> FastAPI:
+def create_app(
+    settings: Settings | None = None,
+    *,
+    embedding_service: EmbeddingService | None = None,
+    vector_repository: VectorRepository | None = None,
+) -> FastAPI:
     """Create a configured FastAPI application."""
 
     resolved_settings = settings or Settings()
-    repository = MetadataRepository(resolved_settings.data_dir / "metadata.sqlite3")
+    metadata = MetadataRepository(resolved_settings.data_dir / "metadata.sqlite3")
+    embeddings = embedding_service or MixedbreadEmbeddingService(
+        model_name=resolved_settings.embedding_model,
+        dimensions=resolved_settings.embedding_dimensions,
+    )
+    vectors = vector_repository or VectorRepository(
+        resolved_settings.data_dir / "vectors",
+        model_name=embeddings.model_name,
+        dimensions=embeddings.dimensions,
+    )
     ingestion_service = IngestionService(
-        repository,
+        metadata,
         resolved_settings.data_dir,
+        embeddings,
+        vectors,
         max_upload_bytes=resolved_settings.max_upload_bytes,
     )
+    retrieval_service = RetrievalService(embeddings, vectors, metadata)
 
     app = FastAPI(
         title="doc2knowledge",
@@ -26,9 +48,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         description="Document ingestion, retrieval, and grounded question answering.",
     )
     app.state.settings = resolved_settings
-    app.state.metadata_repository = repository
+    app.state.metadata_repository = metadata
+    app.state.embedding_service = embeddings
+    app.state.vector_repository = vectors
     app.state.ingestion_service = ingestion_service
+    app.state.retrieval_service = retrieval_service
     app.include_router(documents_router)
+    app.include_router(search_router)
 
     @app.get("/health", tags=["system"])
     def health() -> dict[str, str]:

--- a/src/doc2knowledge/ingestion/service.py
+++ b/src/doc2knowledge/ingestion/service.py
@@ -8,14 +8,15 @@ from pathlib import Path
 from uuid import UUID, uuid4, uuid5
 
 from doc2knowledge.domain import Chunk, Document, DocumentStatus
+from doc2knowledge.embeddings.base import EmbeddingService
 from doc2knowledge.ingestion.chunking import chunk_document
 from doc2knowledge.ingestion.extractors import (
     SUPPORTED_MEDIA_TYPES,
-    ExtractionError,
     UnsupportedMediaTypeError,
     extract_document,
 )
 from doc2knowledge.storage.metadata import MetadataRepository
+from doc2knowledge.storage.vectors import VectorRecord, VectorRepository
 
 
 class UploadTooLargeError(ValueError):
@@ -33,12 +34,16 @@ class IngestionService:
         self,
         repository: MetadataRepository,
         data_dir: Path,
+        embeddings: EmbeddingService,
+        vectors: VectorRepository,
         *,
         max_upload_bytes: int,
         chunk_size: int = 1000,
         chunk_overlap: int = 200,
     ) -> None:
         self._repository = repository
+        self._embeddings = embeddings
+        self._vectors = vectors
         self._documents_dir = data_dir / "documents"
         self._documents_dir.mkdir(parents=True, exist_ok=True)
         self._max_upload_bytes = max_upload_bytes
@@ -75,6 +80,7 @@ class IngestionService:
         document_dir = self._documents_dir / document.id
         document_dir.mkdir(parents=True, exist_ok=False)
         (document_dir / "source").write_bytes(data)
+        vectors_added = False
 
         try:
             extracted = extract_document(data, normalized_media_type)
@@ -94,6 +100,18 @@ class IngestionService:
                 )
                 for draft in drafts
             ]
+            embeddings = self._embeddings.embed_documents([chunk.text for chunk in chunks])
+            self._vectors.add(
+                [
+                    VectorRecord(
+                        chunk_id=chunk.id,
+                        document_id=document.id,
+                        vector=vector,
+                    )
+                    for chunk, vector in zip(chunks, embeddings, strict=True)
+                ]
+            )
+            vectors_added = True
             self._repository.save_chunks(chunks)
             ready = replace(
                 document,
@@ -102,7 +120,9 @@ class IngestionService:
             )
             self._repository.update_document(ready)
             return IngestionResult(document=ready, duplicate=False)
-        except ExtractionError as error:
+        except Exception as error:
+            if vectors_added:
+                self._vectors.delete_document(document.id)
             failed = replace(
                 document,
                 status=DocumentStatus.FAILED,
@@ -118,6 +138,10 @@ class IngestionService:
         return self._repository.list_documents()
 
     def delete_document(self, document_id: str) -> bool:
+        document = self._repository.get_document(document_id)
+        if document is None:
+            return False
+        self._vectors.delete_document(document_id)
         deleted = self._repository.delete_document(document_id)
         if deleted:
             shutil.rmtree(self._documents_dir / document_id, ignore_errors=True)

--- a/src/doc2knowledge/retrieval/__init__.py
+++ b/src/doc2knowledge/retrieval/__init__.py
@@ -1,0 +1,1 @@
+"""Semantic retrieval services."""

--- a/src/doc2knowledge/retrieval/service.py
+++ b/src/doc2knowledge/retrieval/service.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from doc2knowledge.domain import DocumentStatus, RetrievedChunk
+from doc2knowledge.embeddings.base import EmbeddingService
+from doc2knowledge.storage.metadata import MetadataRepository
+from doc2knowledge.storage.vectors import VectorRepository
+
+
+class RetrievalService:
+    def __init__(
+        self,
+        embeddings: EmbeddingService,
+        vectors: VectorRepository,
+        metadata: MetadataRepository,
+    ) -> None:
+        self._embeddings = embeddings
+        self._vectors = vectors
+        self._metadata = metadata
+
+    def search(
+        self,
+        query: str,
+        *,
+        top_k: int,
+        document_ids: set[str] | None = None,
+    ) -> list[RetrievedChunk]:
+        normalized_query = query.strip()
+        if not normalized_query:
+            raise ValueError("query must not be empty")
+        if top_k < 1:
+            raise ValueError("top_k must be positive")
+
+        vector = self._embeddings.embed_query(normalized_query)
+        matches = self._vectors.search(
+            vector,
+            top_k,
+            document_ids=document_ids,
+        )
+        evidence: list[RetrievedChunk] = []
+        for match in matches:
+            chunk = self._metadata.get_chunk(match.chunk_id)
+            document = self._metadata.get_document(match.document_id)
+            if chunk is None or document is None:
+                continue
+            if document.status is not DocumentStatus.READY:
+                continue
+            evidence.append(
+                RetrievedChunk(
+                    chunk=chunk,
+                    document=document,
+                    score=match.score,
+                )
+            )
+        return evidence

--- a/src/doc2knowledge/routes/search.py
+++ b/src/doc2knowledge/routes/search.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import cast
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field, field_validator
+
+from doc2knowledge.config import Settings
+from doc2knowledge.domain import RetrievedChunk
+from doc2knowledge.retrieval.service import RetrievalService
+
+router = APIRouter(tags=["retrieval"])
+
+
+class SearchRequest(BaseModel):
+    query: str
+    top_k: int | None = Field(default=None, ge=1, le=50)
+    document_ids: list[str] | None = None
+
+    @field_validator("query")
+    @classmethod
+    def query_must_not_be_blank(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("query must not be blank")
+        return normalized
+
+
+class EvidenceResponse(BaseModel):
+    chunk_id: str
+    document_id: str
+    filename: str
+    text: str
+    score: float
+    source_page: int | None
+    section: str | None
+
+
+class SearchResponse(BaseModel):
+    evidence: list[EvidenceResponse]
+
+
+def _retrieval(request: Request) -> RetrievalService:
+    return cast(RetrievalService, request.app.state.retrieval_service)
+
+
+def _settings(request: Request) -> Settings:
+    return cast(Settings, request.app.state.settings)
+
+
+def evidence_response(result: RetrievedChunk) -> EvidenceResponse:
+    return EvidenceResponse(
+        chunk_id=result.chunk.id,
+        document_id=result.document.id,
+        filename=result.document.filename,
+        text=result.chunk.text,
+        score=result.score,
+        source_page=result.chunk.source_page,
+        section=result.chunk.section,
+    )
+
+
+@router.post("/search", response_model=SearchResponse)
+def search_documents(payload: SearchRequest, request: Request) -> SearchResponse:
+    results = _retrieval(request).search(
+        payload.query,
+        top_k=payload.top_k or _settings(request).top_k,
+        document_ids=set(payload.document_ids) if payload.document_ids else None,
+    )
+    return SearchResponse(evidence=[evidence_response(result) for result in results])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test support package."""

--- a/tests/api/test_documents.py
+++ b/tests/api/test_documents.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 
 from doc2knowledge.api import create_app
 from doc2knowledge.config import Settings
+from tests.fakes import FakeEmbeddingService
 
 
 def make_client(tmp_path: Path, max_upload_bytes: int = 1024) -> TestClient:
@@ -12,7 +13,10 @@ def make_client(tmp_path: Path, max_upload_bytes: int = 1024) -> TestClient:
             Settings(
                 data_dir=tmp_path,
                 max_upload_bytes=max_upload_bytes,
-            )
+                embedding_model="test-model",
+                embedding_dimensions=3,
+            ),
+            embedding_service=FakeEmbeddingService(),
         )
     )
 

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from doc2knowledge.api import create_app
+from doc2knowledge.config import Settings
+from tests.fakes import FakeEmbeddingService
+
+
+def test_search_returns_ranked_source_metadata(tmp_path: Path) -> None:
+    client = TestClient(
+        create_app(
+            Settings(
+                data_dir=tmp_path,
+                embedding_model="test-model",
+                embedding_dimensions=3,
+            ),
+            embedding_service=FakeEmbeddingService(),
+        )
+    )
+    alpha = client.post(
+        "/documents",
+        files={"file": ("alpha.txt", b"alpha evidence", "text/plain")},
+    ).json()["document"]
+    beta = client.post(
+        "/documents",
+        files={"file": ("beta.txt", b"beta evidence", "text/plain")},
+    ).json()["document"]
+
+    response = client.post("/search", json={"query": "alpha question", "top_k": 2})
+    filtered = client.post(
+        "/search",
+        json={
+            "query": "alpha question",
+            "top_k": 2,
+            "document_ids": [beta["id"]],
+        },
+    )
+
+    assert response.status_code == 200
+    evidence = response.json()["evidence"]
+    assert [item["filename"] for item in evidence] == ["alpha.txt", "beta.txt"]
+    assert evidence[0]["document_id"] == alpha["id"]
+    assert evidence[0]["score"] == 1.0
+    assert evidence[0]["text"] == "alpha evidence"
+
+    assert filtered.status_code == 200
+    assert [item["document_id"] for item in filtered.json()["evidence"]] == [beta["id"]]
+
+
+def test_search_rejects_empty_query(tmp_path: Path) -> None:
+    client = TestClient(
+        create_app(
+            Settings(
+                data_dir=tmp_path,
+                embedding_model="test-model",
+                embedding_dimensions=3,
+            ),
+            embedding_service=FakeEmbeddingService(),
+        )
+    )
+
+    response = client.post("/search", json={"query": "   "})
+
+    assert response.status_code == 422

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,21 @@
+from collections.abc import Sequence
+
+
+class FakeEmbeddingService:
+    model_name = "test-model"
+    dimensions = 3
+
+    def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
+        return [self._vector(text) for text in texts]
+
+    def embed_query(self, query: str) -> list[float]:
+        return self._vector(query)
+
+    @staticmethod
+    def _vector(text: str) -> list[float]:
+        lowered = text.lower()
+        if "alpha" in lowered:
+            return [1.0, 0.0, 0.0]
+        if "beta" in lowered:
+            return [0.0, 1.0, 0.0]
+        return [0.0, 0.0, 1.0]

--- a/tests/ingestion/test_indexing_failure.py
+++ b/tests/ingestion/test_indexing_failure.py
@@ -1,0 +1,42 @@
+from collections.abc import Sequence
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from doc2knowledge.api import create_app
+from doc2knowledge.config import Settings
+
+
+class FailingEmbeddingService:
+    model_name = "test-model"
+    dimensions = 3
+
+    def embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
+        raise RuntimeError("embedding failed")
+
+    def embed_query(self, query: str) -> list[float]:
+        return [1.0, 0.0, 0.0]
+
+
+def test_embedding_failure_marks_document_failed_without_partial_vectors(tmp_path: Path) -> None:
+    app = create_app(
+        Settings(
+            data_dir=tmp_path,
+            embedding_model="test-model",
+            embedding_dimensions=3,
+        ),
+        embedding_service=FailingEmbeddingService(),
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.post(
+        "/documents",
+        files={"file": ("notes.txt", b"alpha evidence", "text/plain")},
+    )
+
+    assert response.status_code == 500
+    documents = client.get("/documents").json()
+    assert len(documents) == 1
+    assert documents[0]["status"] == "failed"
+    assert documents[0]["error_message"] == "embedding failed"
+    assert app.state.vector_repository.size == 0

--- a/tests/retrieval/test_service.py
+++ b/tests/retrieval/test_service.py
@@ -1,0 +1,44 @@
+from datetime import UTC, datetime
+from pathlib import Path
+
+from doc2knowledge.domain import Chunk, Document, DocumentStatus
+from doc2knowledge.retrieval.service import RetrievalService
+from doc2knowledge.storage.metadata import MetadataRepository
+from doc2knowledge.storage.vectors import VectorRecord, VectorRepository
+from tests.fakes import FakeEmbeddingService
+
+
+def test_retrieval_ranks_and_filters_evidence(tmp_path: Path) -> None:
+    metadata = MetadataRepository(tmp_path / "metadata.sqlite3")
+    vectors = VectorRepository(
+        tmp_path / "vectors",
+        model_name="test-model",
+        dimensions=3,
+    )
+    now = datetime(2026, 7, 11, tzinfo=UTC)
+    documents = [
+        Document("d1", "alpha.txt", "text/plain", "h1", DocumentStatus.READY, now, 1, None),
+        Document("d2", "beta.txt", "text/plain", "h2", DocumentStatus.READY, now, 1, None),
+    ]
+    chunks = [
+        Chunk("c1", "d1", 0, "alpha evidence", 1, "Alpha"),
+        Chunk("c2", "d2", 0, "beta evidence", 2, "Beta"),
+    ]
+    for document in documents:
+        metadata.create_document(document)
+    metadata.save_chunks(chunks)
+    vectors.add(
+        [
+            VectorRecord("c1", "d1", [1.0, 0.0, 0.0]),
+            VectorRecord("c2", "d2", [0.0, 1.0, 0.0]),
+        ]
+    )
+    service = RetrievalService(FakeEmbeddingService(), vectors, metadata)
+
+    results = service.search("alpha question", top_k=2)
+    filtered = service.search("alpha question", top_k=2, document_ids={"d2"})
+
+    assert [result.chunk.id for result in results] == ["c1", "c2"]
+    assert results[0].document.filename == "alpha.txt"
+    assert results[0].score == 1.0
+    assert [result.chunk.id for result in filtered] == ["c2"]


### PR DESCRIPTION
## Summary

Clean replacement for PR #8, rebuilt directly from the verified `main` branch to remove stacked-history duplication.

## Changes

- embed and index chunks during ingestion
- compensate vector writes if later persistence fails
- delete vectors before document metadata/source cleanup
- add `RetrievalService`
- add `POST /search` with top-k and document filtering
- return ranked evidence with document, chunk, page, section, and score metadata
- keep tests deterministic and model-download-free

Closes #8 after this replacement is verified and merged.