### PR TITLE
feat: add bounded processing and request observability

### DIFF
--- a/src/doc2knowledge/api.py
+++ b/src/doc2knowledge/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from anyio import CapacityLimiter
 from fastapi import FastAPI
 
 from doc2knowledge import __version__
@@ -9,6 +10,7 @@ from doc2knowledge.embeddings.mixedbread import MixedbreadEmbeddingService
 from doc2knowledge.generation.base import GenerationService
 from doc2knowledge.generation.gemma import GemmaGenerationService
 from doc2knowledge.ingestion.service import IngestionService
+from doc2knowledge.observability import install_request_observability
 from doc2knowledge.retrieval.service import RetrievalService
 from doc2knowledge.routes.documents import router as documents_router
 from doc2knowledge.routes.query import router as query_router
@@ -59,6 +61,7 @@ def create_app(
         version=__version__,
         description="Document ingestion, retrieval, and grounded question answering.",
     )
+    install_request_observability(app)
     app.state.settings = resolved_settings
     app.state.metadata_repository = metadata
     app.state.embedding_service = embeddings
@@ -66,6 +69,7 @@ def create_app(
     app.state.ingestion_service = ingestion_service
     app.state.retrieval_service = retrieval_service
     app.state.generation_service = generation
+    app.state.processing_limiter = CapacityLimiter(resolved_settings.processing_workers)
     app.include_router(documents_router)
     app.include_router(search_router)
     app.include_router(query_router)
@@ -76,6 +80,18 @@ def create_app(
             "status": "ok",
             "service": "doc2knowledge",
             "version": __version__,
+        }
+
+    @app.get("/ready", tags=["system"])
+    def ready() -> dict[str, str | int | bool]:
+        return {
+            "status": "ready",
+            "embedding_model": embeddings.model_name,
+            "embedding_dimensions": embeddings.dimensions,
+            "llm_model": resolved_settings.llm_model,
+            "generation_configured": resolved_settings.gemini_api_key is not None,
+            "processing_workers": resolved_settings.processing_workers,
+            "indexed_vectors": vectors.size,
         }
 
     return app

--- a/src/doc2knowledge/config.py
+++ b/src/doc2knowledge/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     llm_model: str = "gemma-4-31b-it"
     top_k: int = Field(default=6, ge=1, le=50)
     max_upload_bytes: int = Field(default=20 * 1024 * 1024, ge=1)
+    processing_workers: int = Field(default=2, ge=1, le=32)
     gemini_api_key: SecretStr | None = Field(
         default=None,
         validation_alias=AliasChoices(

--- a/src/doc2knowledge/ingestion/service.py
+++ b/src/doc2knowledge/ingestion/service.py
@@ -76,7 +76,12 @@ class IngestionService:
             chunk_count=0,
             error_message=None,
         )
-        self._repository.create_document(document)
+        if not self._repository.create_document(document):
+            duplicate = self._repository.get_document_by_hash(content_hash)
+            if duplicate is None:
+                raise RuntimeError("document hash was claimed but could not be loaded")
+            return IngestionResult(document=duplicate, duplicate=True)
+
         document_dir = self._documents_dir / document.id
         document_dir.mkdir(parents=True, exist_ok=False)
         (document_dir / "source").write_bytes(data)

--- a/src/doc2knowledge/observability.py
+++ b/src/doc2knowledge/observability.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 import time
+from collections.abc import Awaitable, Callable
 from contextvars import ContextVar, Token
 from datetime import UTC, datetime
 from typing import Any
@@ -57,7 +58,10 @@ def install_request_observability(app: FastAPI) -> None:
     logger = configure_logging()
 
     @app.middleware("http")
-    async def request_observability(request: Request, call_next: Any) -> Response:
+    async def request_observability(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
         request_id = _resolve_request_id(request)
         token: Token[str | None] = _request_id.set(request_id)
         started = time.perf_counter()

--- a/src/doc2knowledge/observability.py
+++ b/src/doc2knowledge/observability.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from contextvars import ContextVar, Token
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from fastapi import FastAPI, Request, Response
+
+_REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_request_id: ContextVar[str | None] = ContextVar("request_id", default=None)
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        for field in ("request_id", "method", "path", "status_code", "duration_ms"):
+            value = getattr(record, field, None)
+            if value is not None:
+                payload[field] = value
+        return json.dumps(payload, separators=(",", ":"), default=str)
+
+
+def configure_logging() -> logging.Logger:
+    logger = logging.getLogger("doc2knowledge")
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    if not any(getattr(handler, "doc2knowledge_json", False) for handler in logger.handlers):
+        handler = logging.StreamHandler()
+        handler.setFormatter(JsonFormatter())
+        handler.doc2knowledge_json = True  # type: ignore[attr-defined]
+        logger.addHandler(handler)
+    return logger
+
+
+def current_request_id() -> str | None:
+    return _request_id.get()
+
+
+def _resolve_request_id(request: Request) -> str:
+    candidate = request.headers.get("X-Request-ID", "")
+    if _REQUEST_ID_PATTERN.fullmatch(candidate):
+        return candidate
+    return str(uuid4())
+
+
+def install_request_observability(app: FastAPI) -> None:
+    logger = configure_logging()
+
+    @app.middleware("http")
+    async def request_observability(request: Request, call_next: Any) -> Response:
+        request_id = _resolve_request_id(request)
+        token: Token[str | None] = _request_id.set(request_id)
+        started = time.perf_counter()
+        status_code = 500
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            response.headers["X-Request-ID"] = request_id
+            return response
+        finally:
+            duration_ms = round((time.perf_counter() - started) * 1000, 2)
+            logger.info(
+                "request_completed",
+                extra={
+                    "request_id": request_id,
+                    "method": request.method,
+                    "path": request.url.path,
+                    "status_code": status_code,
+                    "duration_ms": duration_ms,
+                },
+            )
+            _request_id.reset(token)

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Annotated, cast
 
+from anyio import CapacityLimiter, to_thread
 from fastapi import (
     APIRouter,
     File,
@@ -14,6 +15,7 @@ from fastapi import (
 )
 from pydantic import BaseModel, ConfigDict
 
+from doc2knowledge.config import Settings
 from doc2knowledge.domain import Document, DocumentStatus
 from doc2knowledge.ingestion.extractors import (
     EmptyDocumentError,
@@ -23,6 +25,7 @@ from doc2knowledge.ingestion.extractors import (
 from doc2knowledge.ingestion.service import IngestionService, UploadTooLargeError
 
 router = APIRouter(prefix="/documents", tags=["documents"])
+_UPLOAD_READ_CHUNK_BYTES = 1024 * 1024
 
 
 class DocumentResponse(BaseModel):
@@ -47,6 +50,28 @@ def _service(request: Request) -> IngestionService:
     return cast(IngestionService, request.app.state.ingestion_service)
 
 
+def _settings(request: Request) -> Settings:
+    return cast(Settings, request.app.state.settings)
+
+
+def _limiter(request: Request) -> CapacityLimiter:
+    return cast(CapacityLimiter, request.app.state.processing_limiter)
+
+
+async def _read_upload_limited(file: UploadFile, max_bytes: int) -> bytes:
+    data = bytearray()
+    while True:
+        remaining = max_bytes - len(data)
+        chunk = await file.read(min(_UPLOAD_READ_CHUNK_BYTES, remaining + 1))
+        if not chunk:
+            return bytes(data)
+        data.extend(chunk)
+        if len(data) > max_bytes:
+            raise UploadTooLargeError(
+                f"upload contains more than {max_bytes} bytes; limit is {max_bytes}"
+            )
+
+
 def _response(document: Document) -> DocumentResponse:
     return DocumentResponse.model_validate(document)
 
@@ -57,12 +82,14 @@ async def upload_document(
     response: Response,
     file: Annotated[UploadFile, File()],
 ) -> UploadResponse:
-    data = await file.read()
     try:
-        result = _service(request).ingest(
-            filename=file.filename or "document",
-            media_type=file.content_type or "application/octet-stream",
-            data=data,
+        data = await _read_upload_limited(file, _settings(request).max_upload_bytes)
+        result = await to_thread.run_sync(
+            _service(request).ingest,
+            file.filename or "document",
+            file.content_type or "application/octet-stream",
+            data,
+            limiter=_limiter(request),
         )
     except UploadTooLargeError as error:
         raise HTTPException(

--- a/src/doc2knowledge/routes/documents.py
+++ b/src/doc2knowledge/routes/documents.py
@@ -93,7 +93,7 @@ async def upload_document(
         )
     except UploadTooLargeError as error:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail={"code": "upload_too_large", "message": str(error)},
         ) from error
     except UnsupportedMediaTypeError as error:
@@ -103,12 +103,12 @@ async def upload_document(
         ) from error
     except EmptyDocumentError as error:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail={"code": "empty_document", "message": str(error)},
         ) from error
     except ExtractionError as error:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail={"code": "extraction_failed", "message": str(error)},
         ) from error
 

--- a/src/doc2knowledge/storage/metadata.py
+++ b/src/doc2knowledge/storage/metadata.py
@@ -53,14 +53,17 @@ class MetadataRepository:
                 """
             )
 
-    def create_document(self, document: Document) -> None:
+    def create_document(self, document: Document) -> bool:
+        """Atomically claim a content hash, returning False when it already exists."""
+
         with self._connect() as connection:
-            connection.execute(
+            cursor = connection.execute(
                 """
                 INSERT INTO documents (
                     id, filename, media_type, sha256, status,
                     created_at, chunk_count, error_message
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(sha256) DO NOTHING
                 """,
                 (
                     document.id,
@@ -73,6 +76,7 @@ class MetadataRepository:
                     document.error_message,
                 ),
             )
+        return cursor.rowcount > 0
 
     def update_document(self, document: Document) -> None:
         with self._connect() as connection:

--- a/tests/ingestion/test_concurrent_duplicate.py
+++ b/tests/ingestion/test_concurrent_duplicate.py
@@ -1,0 +1,56 @@
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier, Lock
+
+from doc2knowledge.domain import DocumentStatus
+from doc2knowledge.ingestion.service import IngestionService
+from doc2knowledge.storage.metadata import MetadataRepository
+from doc2knowledge.storage.vectors import VectorRepository
+from tests.fakes import FakeEmbeddingService
+
+
+class RacingMetadataRepository(MetadataRepository):
+    def __init__(self, database_path: Path) -> None:
+        super().__init__(database_path)
+        self._initial_lookup_barrier = Barrier(2)
+        self._lookup_lock = Lock()
+        self._initial_lookups = 0
+
+    def get_document_by_hash(self, sha256: str):  # type: ignore[no-untyped-def]
+        with self._lookup_lock:
+            should_wait = self._initial_lookups < 2
+            if should_wait:
+                self._initial_lookups += 1
+        result = super().get_document_by_hash(sha256)
+        if should_wait:
+            self._initial_lookup_barrier.wait(timeout=5)
+        return result
+
+
+def test_concurrent_identical_uploads_share_one_document(tmp_path: Path) -> None:
+    repository = RacingMetadataRepository(tmp_path / "metadata.sqlite3")
+    vectors = VectorRepository(
+        tmp_path / "vectors",
+        model_name="test-model",
+        dimensions=3,
+    )
+    service = IngestionService(
+        repository,
+        tmp_path,
+        FakeEmbeddingService(),
+        vectors,
+        max_upload_bytes=1024,
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(service.ingest, f"notes-{index}.txt", "text/plain", b"alpha")
+            for index in range(2)
+        ]
+        results = [future.result(timeout=10) for future in futures]
+
+    assert sorted(result.duplicate for result in results) == [False, True]
+    assert len({result.document.id for result in results}) == 1
+    assert vectors.size == 1
+    assert len(repository.list_documents()) == 1
+    assert repository.list_documents()[0].status is DocumentStatus.READY

--- a/tests/storage/test_metadata.py
+++ b/tests/storage/test_metadata.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -41,7 +42,7 @@ def test_repository_persists_documents_chunks_and_deletion(tmp_path: Path) -> No
         ),
     ]
 
-    repository.create_document(document)
+    assert repository.create_document(document) is True
     repository.save_chunks(chunks)
     repository.update_document(
         Document(
@@ -67,3 +68,13 @@ def test_repository_persists_documents_chunks_and_deletion(tmp_path: Path) -> No
     assert reopened.get_document(document.id) is None
     assert reopened.get_chunks(document.id) == []
     assert reopened.delete_document(document.id) is False
+
+
+def test_repository_atomically_rejects_a_duplicate_content_hash(tmp_path: Path) -> None:
+    repository = MetadataRepository(tmp_path / "metadata.sqlite3")
+    original = make_document()
+    duplicate = replace(original, id="doc-2", filename="renamed.txt")
+
+    assert repository.create_document(original) is True
+    assert repository.create_document(duplicate) is False
+    assert repository.get_document_by_hash(original.sha256) == original

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,0 +1,44 @@
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from anyio import run
+from fastapi import UploadFile
+
+from doc2knowledge.api import create_app
+from doc2knowledge.config import Settings
+from doc2knowledge.ingestion.service import UploadTooLargeError
+from doc2knowledge.routes.documents import _read_upload_limited
+from tests.fakes import FakeEmbeddingService
+
+
+def test_upload_reader_stops_at_limit_plus_one_byte() -> None:
+    upload = UploadFile(file=BytesIO(b"abcdef"), filename="large.txt")
+
+    with pytest.raises(UploadTooLargeError, match="limit is 4"):
+        run(_read_upload_limited, upload, 4)
+
+    assert upload.file.tell() == 5
+
+
+def test_upload_reader_accepts_content_at_exact_limit() -> None:
+    upload = UploadFile(file=BytesIO(b"abcd"), filename="exact.txt")
+
+    assert run(_read_upload_limited, upload, 4) == b"abcd"
+    assert upload.file.tell() == 4
+
+
+def test_app_creates_one_shared_processing_limiter(tmp_path: Path) -> None:
+    app = create_app(
+        Settings(
+            data_dir=tmp_path,
+            embedding_model="test-model",
+            embedding_dimensions=3,
+            processing_workers=3,
+        ),
+        embedding_service=FakeEmbeddingService(),
+    )
+
+    limiter = app.state.processing_limiter
+    assert limiter.total_tokens == 3
+    assert app.state.processing_limiter is limiter

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from doc2knowledge.api import create_app
+from doc2knowledge.config import Settings
+from tests.fakes import FakeEmbeddingService
+
+
+def test_readiness_reports_models_capacity_and_generation_state(tmp_path: Path) -> None:
+    client = TestClient(
+        create_app(
+            Settings(
+                data_dir=tmp_path,
+                embedding_model="test-model",
+                embedding_dimensions=3,
+                llm_model="gemma-4-31b-it",
+                processing_workers=2,
+            ),
+            embedding_service=FakeEmbeddingService(),
+        )
+    )
+
+    response = client.get("/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ready",
+        "embedding_model": "test-model",
+        "embedding_dimensions": 3,
+        "llm_model": "gemma-4-31b-it",
+        "generation_configured": False,
+        "processing_workers": 2,
+        "indexed_vectors": 0,
+    }
+    assert "api_key" not in response.text.lower()
+    assert "secret" not in response.text.lower()

--- a/tests/test_request_ids.py
+++ b/tests/test_request_ids.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from doc2knowledge.api import create_app
+from doc2knowledge.config import Settings
+from tests.fakes import FakeEmbeddingService
+
+
+def make_client(tmp_path: Path) -> TestClient:
+    return TestClient(
+        create_app(
+            Settings(
+                data_dir=tmp_path,
+                embedding_model="test-model",
+                embedding_dimensions=3,
+            ),
+            embedding_service=FakeEmbeddingService(),
+        )
+    )
+
+
+def test_request_id_is_generated_and_returned(tmp_path: Path) -> None:
+    response = make_client(tmp_path).get("/health")
+
+    request_id = response.headers["x-request-id"]
+    assert request_id
+    assert len(request_id) == 36
+
+
+def test_valid_caller_request_id_is_preserved(tmp_path: Path) -> None:
+    response = make_client(tmp_path).get(
+        "/health",
+        headers={"X-Request-ID": "client-request-123"},
+    )
+
+    assert response.headers["x-request-id"] == "client-request-123"
+
+
+def test_unsafe_request_id_is_replaced(tmp_path: Path) -> None:
+    unsafe_request_id = "bad request id"
+    response = make_client(tmp_path).get(
+        "/health",
+        headers={"X-Request-ID": unsafe_request_id},
+    )
+
+    assert response.headers["x-request-id"] != unsafe_request_id
+    assert len(response.headers["x-request-id"]) == 36


### PR DESCRIPTION
## Summary

Clean replacement for PR #10, rebuilt directly from the verified `main` branch.

## Processing

- moves extraction, embedding, and indexing to AnyIO worker threads
- uses one app-wide `CapacityLimiter` created during application setup
- bounds concurrency through `DOC2KNOWLEDGE_PROCESSING_WORKERS`
- reads uploads incrementally and rejects after the configured limit plus one byte instead of buffering the full request
- atomically claims content hashes so concurrent identical uploads share one document rather than colliding in SQLite

## Observability

- adds generated or caller-supplied safe `X-Request-ID` values
- replaces unsafe/log-injection request IDs
- emits structured JSON request-completion logs
- stores request IDs in context-local state

## Readiness

- adds `GET /ready` with model names, embedding dimensions, processing capacity, vector count, and generation configuration state
- does not expose secrets or load the embedding model

## Review fixes over original PR #10

- removes the lazy limiter initialization race
- prevents oversized uploads from being fully read into memory
- handles the concurrent duplicate-upload race atomically
- uses current Starlette HTTP status constant names
- adds regression tests for bounded reads, shared capacity, and concurrent deduplication

Fresh CI passes Ruff lint/format, strict mypy, 38 tests at 91.85% coverage, package build, and Docker build.