### PR TITLE
feat: add retrieval evaluation harness and operating docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
 # doc2knowledge
 
-A document ingestion, retrieval, and evidence-grounded question-answering service.
+A local-first document ingestion, semantic retrieval, and evidence-grounded question-answering service.
 
-The project is being modernized in staged pull requests. The current foundation provides a packaged FastAPI application, typed configuration, health endpoint, repeatable development commands, Docker runtime, and CI checks.
+## Architecture
+
+- FastAPI application packaged under `src/doc2knowledge`
+- SQLite document and chunk metadata
+- one persistent, thread-safe FAISS collection across all documents
+- `mixedbread-ai/mxbai-embed-large-v1` document/query embeddings
+- configurable `gemma-4-31b-it` generation through the Google Gen AI API
+- explicit citations resolved to document, chunk, page, and section metadata
+- bounded worker-thread processing for extraction, embedding, and indexing
+- structured request logs and caller-visible request IDs
 
 ## Requirements
 
 - Python 3.11+
 - Docker, optional
+- enough local memory to load the embedding model for real ingestion/search
+- a `GEMINI_API_KEY` created in Google AI Studio for `/query`
 
 ## Local development
 
@@ -21,19 +32,73 @@ The API starts on `http://localhost:8000`.
 
 ```bash
 curl http://localhost:8000/health
+curl http://localhost:8000/ready
 ```
 
-Expected response:
-
-```json
-{"status":"ok","service":"doc2knowledge","version":"0.1.0"}
-```
+`/health` confirms the process is serving requests. `/ready` reports configured models, embedding dimensions, processing capacity, indexed-vector count, and whether generation is configured without exposing secrets or forcing a model download.
 
 ## Docker
 
 ```bash
 docker build -t doc2knowledge:local .
-docker run --rm -p 8000:8000 -v "$(pwd)/data:/app/data" doc2knowledge:local
+docker run --rm \
+  -p 8000:8000 \
+  -v "$(pwd)/data:/app/data" \
+  -v "$HOME/.cache/huggingface:/home/app/.cache/huggingface" \
+  -e GEMINI_API_KEY \
+  doc2knowledge:local
+```
+
+The embedding model is loaded lazily on the first ingestion or search request. Persist the Hugging Face cache between container runs to avoid repeated downloads.
+
+## API workflow
+
+### Upload a document
+
+```bash
+curl -X POST http://localhost:8000/documents \
+  -F 'file=@notes.pdf'
+```
+
+Supported initial formats are PDF with extractable text, HTML, plain text, and Markdown. Uploads are read up to the configured byte limit, content-hashed, deduplicated, chunked, embedded, and persisted. Concurrent identical uploads atomically resolve to the same document.
+
+### Search evidence
+
+```bash
+curl -X POST http://localhost:8000/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"What does the document say about revenue?","top_k":6}'
+```
+
+`/search` does not require a Gemini API key. It returns ranked chunks with similarity scores and source metadata. An optional `document_ids` list restricts retrieval to selected documents.
+
+### Generate a cited answer
+
+```bash
+curl -X POST http://localhost:8000/query \
+  -H 'Content-Type: application/json' \
+  -d '{"question":"What does the document say about revenue?","top_k":6}'
+```
+
+The generation prompt contains only retrieved evidence. Non-abstaining answers must cite valid source labels such as `[S1]`; invalid, invented, or uncited answers are rejected.
+
+### List and delete documents
+
+```bash
+curl http://localhost:8000/documents
+curl http://localhost:8000/documents/<document-id>
+curl -X DELETE http://localhost:8000/documents/<document-id>
+```
+
+Deletion removes the original file, metadata, chunks, and vectors.
+
+## Request tracing
+
+Every successful response includes an `X-Request-ID`. A safe caller-supplied ID is preserved; malformed values are replaced. Request-completion logs are emitted as JSON with request ID, method, path, status, and duration.
+
+```bash
+curl -i http://localhost:8000/health \
+  -H 'X-Request-ID: local-debug-123'
 ```
 
 ## Configuration
@@ -48,13 +113,42 @@ Application settings use the `DOC2KNOWLEDGE_` prefix unless noted otherwise.
 | `DOC2KNOWLEDGE_LLM_MODEL` | `gemma-4-31b-it` |
 | `DOC2KNOWLEDGE_TOP_K` | `6` |
 | `DOC2KNOWLEDGE_MAX_UPLOAD_BYTES` | `20971520` |
+| `DOC2KNOWLEDGE_PROCESSING_WORKERS` | `2` |
 | `GEMINI_API_KEY` | unset |
 
-No API key or model download is required for the foundation test suite.
+The default test suite injects fake embedding and generation services. CI does not download models or call external APIs.
 
-## Roadmap
+## Retrieval evaluation
 
-See:
+1. Start the service and ingest the benchmark documents.
+2. Copy `eval/questions.example.json` to `eval/questions.json`.
+3. Replace the example questions and relevant filenames with the benchmark set. Filenames should be stable and unique within the benchmark corpus.
+4. Run:
+
+```bash
+python scripts/evaluate_retrieval.py eval/questions.json --k 6
+```
+
+The command calls `/search` and prints:
+
+- `recall_at_k`: fraction of relevant source documents represented in the first `k` retrieved chunks
+- `mean_reciprocal_rank`: reciprocal rank of the first relevant chunk, cut off at `k`
+- `mean_unique_sources_at_k`: average number of distinct source documents represented in the first `k` chunks
+
+The diversity metric makes repeated chunks from one source visible instead of silently treating a redundant result list as broad retrieval. Keep the corpus and questions versioned so embedding, chunking, hybrid retrieval, and reranking changes can be compared against the same baseline.
+
+## Development checks
+
+```bash
+ruff check .
+ruff format --check .
+mypy src
+pytest -q --cov=doc2knowledge --cov-report=term-missing
+python -m build
+docker build -t doc2knowledge:check .
+```
+
+## Design and implementation plan
 
 - `docs/superpowers/specs/2026-07-11-document-to-knowledge-modernization-design.md`
 - `docs/superpowers/plans/2026-07-11-document-to-knowledge-modernization.md`

--- a/eval/questions.example.json
+++ b/eval/questions.example.json
@@ -1,0 +1,12 @@
+{
+  "questions": [
+    {
+      "query": "When was Alpha founded?",
+      "relevant_filenames": ["alpha.txt"]
+    },
+    {
+      "query": "Which document discusses the Beta launch?",
+      "relevant_filenames": ["beta.txt"]
+    }
+  ]
+}

--- a/scripts/evaluate_retrieval.py
+++ b/scripts/evaluate_retrieval.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.error
+import urllib.request
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from doc2knowledge.evaluation import RankingCase, evaluate_rankings
+
+
+def _parse_k(value: str) -> int:
+    parsed = int(value)
+    if not 1 <= parsed <= 50:
+        raise argparse.ArgumentTypeError("k must be between 1 and 50")
+    return parsed
+
+
+def search(base_url: str, query: str, top_k: int) -> tuple[str, ...]:
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}/search",
+        data=json.dumps({"query": query, "top_k": top_k}).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            payload: Any = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        body = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"search request failed with HTTP {error.code}: {body}") from error
+    except urllib.error.URLError as error:
+        raise RuntimeError(f"search request failed: {error}") from error
+
+    if not isinstance(payload, dict) or not isinstance(payload.get("evidence"), list):
+        raise RuntimeError("search response did not contain an evidence list")
+    filenames: list[str] = []
+    for item in payload["evidence"]:
+        if not isinstance(item, dict) or not isinstance(item.get("filename"), str):
+            raise RuntimeError("search evidence item did not contain a filename")
+        filenames.append(item["filename"])
+    return tuple(filenames)
+
+
+def load_cases(path: Path, base_url: str, top_k: int) -> list[RankingCase]:
+    payload: Any = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or not isinstance(payload.get("questions"), list):
+        raise ValueError("benchmark file must contain a questions list")
+    if not payload["questions"]:
+        raise ValueError("benchmark questions list must not be empty")
+
+    cases: list[RankingCase] = []
+    for item in payload["questions"]:
+        if not isinstance(item, dict):
+            raise ValueError("every benchmark question must be an object")
+        query = item.get("query")
+        relevant_values = item.get("relevant_filenames")
+        if not isinstance(query, str) or not query.strip():
+            raise ValueError("every benchmark question must contain a non-empty query")
+        if not isinstance(relevant_values, list) or not relevant_values:
+            raise ValueError("every benchmark question must contain relevant_filenames")
+        if any(not isinstance(value, str) or not value.strip() for value in relevant_values):
+            raise ValueError("relevant_filenames must contain non-empty strings")
+
+        cases.append(
+            RankingCase(
+                query=query.strip(),
+                relevant_ids=frozenset(value.strip() for value in relevant_values),
+                ranked_ids=search(base_url, query.strip(), top_k),
+            )
+        )
+    return cases
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure document recall@k, MRR@k, and source diversity against a running "
+            "doc2knowledge service."
+        )
+    )
+    parser.add_argument("questions", type=Path)
+    parser.add_argument("--base-url", default="http://localhost:8000")
+    parser.add_argument("--k", type=_parse_k, default=6)
+    args = parser.parse_args()
+
+    report = evaluate_rankings(
+        load_cases(args.questions, args.base_url, args.k),
+        k=args.k,
+    )
+    print(json.dumps(asdict(report), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/doc2knowledge/evaluation.py
+++ b/src/doc2knowledge/evaluation.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RankingCase:
+    query: str
+    relevant_ids: frozenset[str]
+    ranked_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class EvaluationReport:
+    query_count: int
+    k: int
+    recall_at_k: float
+    mean_reciprocal_rank: float
+    mean_unique_sources_at_k: float
+
+
+def evaluate_rankings(cases: list[RankingCase], *, k: int) -> EvaluationReport:
+    if not cases:
+        raise ValueError("at least one ranking case is required")
+    if k < 1:
+        raise ValueError("k must be positive")
+    if any(not case.query.strip() for case in cases):
+        raise ValueError("every ranking case must contain a non-empty query")
+    if any(not case.relevant_ids for case in cases):
+        raise ValueError("every ranking case must contain at least one relevant ID")
+    if any(not identifier.strip() for case in cases for identifier in case.relevant_ids):
+        raise ValueError("relevant IDs must not be blank")
+    if any(not identifier.strip() for case in cases for identifier in case.ranked_ids):
+        raise ValueError("ranked IDs must not be blank")
+
+    recalls: list[float] = []
+    reciprocal_ranks: list[float] = []
+    unique_source_counts: list[float] = []
+    for case in cases:
+        top_k = case.ranked_ids[:k]
+        retrieved_relevant = len(case.relevant_ids.intersection(top_k))
+        recalls.append(retrieved_relevant / len(case.relevant_ids))
+        unique_source_counts.append(float(len(set(top_k))))
+
+        reciprocal_rank = 0.0
+        for rank, candidate in enumerate(top_k, start=1):
+            if candidate in case.relevant_ids:
+                reciprocal_rank = 1.0 / rank
+                break
+        reciprocal_ranks.append(reciprocal_rank)
+
+    return EvaluationReport(
+        query_count=len(cases),
+        k=k,
+        recall_at_k=sum(recalls) / len(recalls),
+        mean_reciprocal_rank=sum(reciprocal_ranks) / len(reciprocal_ranks),
+        mean_unique_sources_at_k=sum(unique_source_counts) / len(unique_source_counts),
+    )

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,73 @@
+import pytest
+
+from doc2knowledge.evaluation import RankingCase, evaluate_rankings
+
+
+def test_evaluation_reports_recall_mrr_and_source_diversity_at_k() -> None:
+    report = evaluate_rankings(
+        [
+            RankingCase(
+                query="alpha",
+                relevant_ids=frozenset({"a", "b"}),
+                ranked_ids=("a", "x", "b"),
+            ),
+            RankingCase(
+                query="beta",
+                relevant_ids=frozenset({"c"}),
+                ranked_ids=("x", "c", "y"),
+            ),
+        ],
+        k=2,
+    )
+
+    assert report.query_count == 2
+    assert report.k == 2
+    assert report.recall_at_k == pytest.approx(0.75)
+    assert report.mean_reciprocal_rank == pytest.approx(0.75)
+    assert report.mean_unique_sources_at_k == pytest.approx(2.0)
+
+
+def test_mrr_is_cut_off_at_k() -> None:
+    report = evaluate_rankings(
+        [RankingCase("alpha", frozenset({"a"}), ("x", "y", "a"))],
+        k=2,
+    )
+
+    assert report.recall_at_k == 0.0
+    assert report.mean_reciprocal_rank == 0.0
+    assert report.mean_unique_sources_at_k == 2.0
+
+
+def test_source_diversity_exposes_repeated_chunks_from_one_document() -> None:
+    report = evaluate_rankings(
+        [RankingCase("alpha", frozenset({"a"}), ("x", "x", "a"))],
+        k=3,
+    )
+
+    assert report.recall_at_k == 1.0
+    assert report.mean_reciprocal_rank == pytest.approx(1 / 3)
+    assert report.mean_unique_sources_at_k == 2.0
+
+
+def test_evaluation_handles_no_results_and_validates_inputs() -> None:
+    report = evaluate_rankings(
+        [RankingCase("missing", frozenset({"a"}), ())],
+        k=5,
+    )
+
+    assert report.recall_at_k == 0.0
+    assert report.mean_reciprocal_rank == 0.0
+    assert report.mean_unique_sources_at_k == 0.0
+
+    with pytest.raises(ValueError, match="at least one"):
+        evaluate_rankings([], k=1)
+    with pytest.raises(ValueError, match="positive"):
+        evaluate_rankings([RankingCase("q", frozenset({"a"}), ())], k=0)
+    with pytest.raises(ValueError, match="non-empty query"):
+        evaluate_rankings([RankingCase(" ", frozenset({"a"}), ())], k=1)
+    with pytest.raises(ValueError, match="at least one relevant"):
+        evaluate_rankings([RankingCase("q", frozenset(), ())], k=1)
+    with pytest.raises(ValueError, match="Relevant IDs|relevant IDs"):
+        evaluate_rankings([RankingCase("q", frozenset({""}), ())], k=1)
+    with pytest.raises(ValueError, match="Ranked IDs|ranked IDs"):
+        evaluate_rankings([RankingCase("q", frozenset({"a"}), ("",))], k=1)


### PR DESCRIPTION
## Summary

Clean replacement for PR #11, rebuilt directly from the verified `main` branch after PR #15.

## Evaluation

- adds reusable ranking cases and evaluation reports
- measures document recall@k over retrieved chunks
- measures MRR cut off at k
- reports mean unique source documents at k to expose redundant same-document chunks
- validates empty benchmarks, invalid k values, blank queries, and malformed identifiers
- adds a CLI against a running `/search` endpoint with explicit HTTP and response-shape errors
- adds a versionable example question-set format

## Documentation

- expands architecture and runtime requirements
- documents upload, search, query, delete, health, readiness, and request tracing
- covers model-cache persistence, processing limits, configuration, CI behavior, and benchmark execution

## Review fixes over original PR #11

- corrects the old test's mathematically wrong recall@2 expectation from 0.50 to 0.75
- makes MRR consistently respect the k cutoff
- adds source-diversity reporting so repeated chunks from one document are visible
- adds stronger benchmark and API-response validation

Fresh CI passes Ruff lint/format, strict mypy, 42 tests at 92.32% coverage, package build, and Docker build.